### PR TITLE
Restore About Mechanics improvements overwritten by Archbee sync

### DIFF
--- a/docs/mechanics/About-Mechanics.md
+++ b/docs/mechanics/About-Mechanics.md
@@ -1,9 +1,8 @@
 ---
 title: About Mechanics
-slug: mechanics/about
 docTags: 
 createdAt: Sun Apr 26 2026 18:22:16 GMT+0000 (Coordinated Universal Time)
-updatedAt: Tue Apr 28 2026 13:32:59 GMT+0000 (Coordinated Universal Time)
+updatedAt: Sun Apr 26 2026 19:21:47 GMT+0000 (Coordinated Universal Time)
 ---
 
 This page explains the structure of the Mechanics sub-project, provides links to design files, and outlines how to contribute to Flipper One's mechanical development.
@@ -76,7 +75,7 @@ For all methods of navigating models in Onshape, view :Link[the official documen
 
 ### How to export 3D models
 
-You can export the models for printing to test ergonomics or develop your own modules for Flipper One. Onshape supports exporting models in various formats.
+You can export the models for printing to test ergonomics, or develop your own modules for Flipper One. Onshape supports exporting models in various formats.
 
 :::hint{type="info"}
 **Supported export formats:** STEP, STL, OBJ, SOLIDWORKS, IGES, Parasolid, GLTF, RHINO, COLLADA, JT, PVZ, ACIS, and 3MF.
@@ -94,7 +93,7 @@ Click the :inlineImage[]{src="https://api.archbee.com/api/optimize/3StCFqarJkJQZ
 :::WorkflowBlockItem
 Select your preferred export format.
 
-![](https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/t8WnvvpTLQvxXyQunfVnF-20260426-190635.png)
+![Onshape export formats](/files/pics/export-formats.png "Select your preferred export format")
 :::
 
 :::WorkflowBlockItem
@@ -143,7 +142,7 @@ Design versioning scheme includes two parts: `<LETTER>.<NUMBER>` (for example, A
 
 ***
 
-# How to contribute
+## How to contribute
 
 :::hint{type="info"}
 To contribute to the Mechanics sub-project, you need to have a GitHub account. You can create one on the :Link[GitHub website]{href="https://github.com/signup" newTab="true" hasDisabledNofollow="false"}.
@@ -151,15 +150,21 @@ To contribute to the Mechanics sub-project, you need to have a GitHub account. Y
 
 ![](https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/Mo4LPAlsvBYBJ0LdlcZWd-20260423-202546.jpg)
 
-Anyone can contribute to the Mechanics sub-project:
+**Before you start:** Check open tasks in the :Link[task tracker]{href="https://github.com/orgs/flipperdevices/projects/15" newTab="true" hasDisabledNofollow="false"} to see what the team is already working on or where help is wanted.
 
-**Step 0:** Check open tasks in the :Link[task tracker]{href="https://github.com/orgs/flipperdevices/projects/15" newTab="true" hasDisabledNofollow="false"}.
+::::WorkflowBlock
+:::WorkflowBlockItem
+Download 3D models from :Link[GitHub]{href="https://github.com/flipperdevices/flipperone-mechanics" newTab="true" hasDisabledNofollow="false"} or :Link[Onshape]{href="https://cad.onshape.com/documents/32ee3b79861e4ff5fe28ee3b/w/8eca0dcb9e92b0271d434028/e/adb36e3c67cc1a734691cf20" newTab="true" hasDisabledNofollow="false"}.
+:::
 
-**Step 1:** Download 3D models from :Link[GitHub]{href="https://github.com/flipperdevices/flipperone-mechanics" newTab="true" hasDisabledNofollow="false"} or :Link[Onshape]{href="https://cad.onshape.com/documents/32ee3b79861e4ff5fe28ee3b/w/8eca0dcb9e92b0271d434028/e/adb36e3c67cc1a734691cf20" newTab="true" hasDisabledNofollow="false"}.
+:::WorkflowBlockItem
+Edit the 3D models using any CAD tool.
+:::
 
-**Step 2:** Edit the 3D models using any CAD tool.
-
-**Step 3:** Submit your work as a **pull request** to our GitHub repo. If there is an open task, you can submit your work in the comment section.
+:::WorkflowBlockItem
+Submit your work as a **pull request** to our GitHub repo. If there is an open task, you can submit your work in the comment section.
+:::
+::::
 
 ***
 
@@ -169,61 +174,61 @@ If you have an idea for improving the design of Flipper One, you're welcome to c
 
 ::::WorkflowBlock
 :::WorkflowBlockItem
-Go to the :Link[flipperone-mechanics]{href="https://github.com/flipperdevices/flipperone-mechanics" newTab="true" hasDisabledNofollow="false"} repository.
+**Open the repository.** Go to :Link[flipperone-mechanics]{href="https://github.com/flipperdevices/flipperone-mechanics" newTab="true" hasDisabledNofollow="false"} on GitHub.
 :::
 
 :::WorkflowBlockItem
-Copy the repository to your GitHub account by clicking the **Fork** button in the upper-right corner, then confirm your action.
+**Fork the repository.** Click the **Fork** button in the upper-right corner and confirm to copy it to your GitHub account.
 
 ![](https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/2jGWJn2oQ6yvqc05wUV9x-20260426-190852.png)
 :::
 
 :::WorkflowBlockItem
-In your copied repository, go to the **CURRENT** folder.
+**In your fork, open the CURRENT folder.**
 :::
 
 :::WorkflowBlockItem
-Click the **Add file&#x20;**&#x64;ropdown button.
+**Click the Add file dropdown.**
 
 ![](https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/1hy5kMVH_S45lKYwnnJ3e-20260426-191010.png)
 :::
 
 :::WorkflowBlockItem
-Select :inlineImage[]{src="https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/hHcooERJ1R9C3tGrRKQOq_image.png" alt caption}**Upload files**.
+**Select :inlineImage[]{src="https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/hHcooERJ1R9C3tGrRKQOq_image.png" alt caption}Upload files** from the dropdown.
 :::
 
 :::WorkflowBlockItem
-Drag and drop a file, or click **choose your files** to select it from your computer.
+**Upload your files.** Drag and drop a file, or click **choose your files** to select it from your computer.
 :::
 
 :::WorkflowBlockItem
-After uploading, scroll down to **Commit changes**.
+**After uploading, scroll down to Commit changes.**
 :::
 
 :::WorkflowBlockItem
-Add a clear, concise commit **description** (for example: *Add bumps to aluminum bracket*).
+**Write a commit description.** Keep it clear and concise — for example, *Add bumps to aluminum bracket*.
 
 ![](https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/cMstWOb0PqfMBq6LcdXju-20260426-191048.png)
 :::
 
 :::WorkflowBlockItem
-Click **Commit changes** — this will save the changes in your repository.
+**Click Commit changes** to save them in your repository.
 :::
 
 :::WorkflowBlockItem
-In your repository, click **Contribute -> Open pull request**.
+**Open a pull request.** In your repository, click **Contribute → Open pull request**.
 
 ![](https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/ObqBpjO7nGF1wdtmfzyiF-20260426-191221.png)
 :::
 
 :::WorkflowBlockItem
-Check that your changes will be pushed to the repository: **flipperdevices/flipperone-mechanics**, base: **dev**.
+**Check the target branch.** Confirm changes will be pushed to **flipperdevices/flipperone-mechanics**, base: **dev**.
 
 ![](https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/e4hVU57mbgVlqinJAFkfw-20260426-191307.png)
 :::
 
 :::WorkflowBlockItem
-Add a pull request **title** and a **description** in Markdown — you can preview your description by clicking **Preview**.
+**Add a title and description.** Write the pull request **title** and a **description** in Markdown — preview it with **Preview**.
 
 We highly recommend attaching screenshots that show what changed and a link to the open task this pull request is associated with.
 
@@ -231,7 +236,7 @@ We highly recommend attaching screenshots that show what changed and a link to t
 :::
 
 :::WorkflowBlockItem
-Click **Create pull request**.
+**Click Create pull request.**
 :::
 ::::
 
@@ -246,31 +251,25 @@ We review all ideas carefully! We may ask additional questions about your idea i
 
 To keep collaboration productive, please keep comments on-topic. Open tasks are for contribution-related discussion only. If you have an idea or concern, first turn it into a concrete contribution and share it as a comment on a task. For general questions or discussions, you’re always welcome to join the conversation on :Link[social media]{href="https://x.com/Flipper_RND" newTab="true" hasDisabledNofollow="false"} or :Link[Discord]{href="https://discord.com/invite/flipper" newTab="true" hasDisabledNofollow="false"}!
 
-:::Paragraph{indent="1"}
-**Bad vs good comments:**
-:::
-
-:::Paragraph{indent="1"}
-❌ — I like the green button instead of the orange one
-👍 — I think the green button works better. Here's an example I made: `mypicture.jpg`&#x20;
-:::
 ::::
+
+‎ 
 
 Open tasks that need the community's help are labeled **help wanted**. If you have ideas on how to improve the design, you can contribute by commenting on the task and attaching screenshots, videos, or links:
 
 :::::WorkflowBlock
 :::WorkflowBlockItem
-In the :Link[Mechanics GitHub project]{href="https://github.com/orgs/flipperdevices/projects/15" newTab="true" hasDisabledNofollow="false"}, click the open task you want to contribute to.
+**Pick a task.** In the :Link[Mechanics GitHub project]{href="https://github.com/orgs/flipperdevices/projects/15" newTab="true" hasDisabledNofollow="false"}, browse the open tasks and click the one labeled **help wanted** that you want to contribute to.
 :::
 
 ::::WorkflowBlockItem
-In the comments section, clearly write your comment and attach a screenshot, video, or provide a link to your 3D model on :Link[Onshape]{href="https://www.onshape.com/en/" newTab="true" hasDisabledNofollow="false"}. Unfortunately, `.stp` files can't be attached to the comment.
+**Write your suggestion.** In the comments section, clearly describe your suggestion and attach a screenshot, video, or a link to your 3D model on :Link[Onshape]{href="https://www.onshape.com/en/" newTab="true" hasDisabledNofollow="false"}. Unfortunately, `.stp` files can't be attached to the comment.
 
 :::hint{type="info"}
 **Important:** If you share a link to your design on Onshape, ensure the model is accessible for others to view.
 :::
 
-![](https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/9tONC29IVBE4gTRPBn5wT-20260426-192014.png)
+![Good vs bad comment on a Mechanics task](/files/pics/mechanics-good-vs-bad-comment.png)
 
 **Attachment size limit:**
 
@@ -279,7 +278,7 @@ In the comments section, clearly write your comment and attach a screenshot, vid
 ::::
 
 :::WorkflowBlockItem
-Click **Comment**.
+**Click Comment** to submit.
 :::
 :::::
 


### PR DESCRIPTION
Re-applies changes from c82f0c3 that the Archbee web-editor sync commit fffa26c overwrote:

- Restyle Submit/Suggest WorkflowBlocks: bold key action, squash redundancies
- Convert plain Step 0..3 to Before-you-start note + WorkflowBlock
- Promote H1 to H2 for How to contribute
- Replace Good-vs-bad comment image with /files/pics/mechanics-good-vs-bad-comment.png
- Replace Export formats image with /files/pics/export-formats.png (leading-slash form)