### PR TITLE
archbee: Validate configuration, structure, and links

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,9 @@ name: Validate
 
 on:
   pull_request:
+  push:
+    branches:
+      - public-release
 
 jobs:
   archbee:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,25 @@
+name: Validate
+
+on:
+  pull_request:
+
+jobs:
+  archbee:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+
+      - name: Install Archbee CLI
+        run: npm install --global @archbee/cli
+
+      # Detects incorrect configuration and errors in the declared documentation structure
+      - name: Validate configuration and structure
+        run: archbee validate
+
+      - name: Detect broken links
+        run: archbee broken-links

--- a/archbee.json
+++ b/archbee.json
@@ -1,5 +1,8 @@
 {
+  "name": "Flipper One Documentation",
   "root": "./docs",
+  "publishSpace": true,
+  "docsPath": "docs/",
   "structure": {
     "readme": "Welcome.md",
     "summary": "Summary.md",
@@ -138,7 +141,7 @@
             "isCategory": false,
             "path": "mechanics/Hardware-expansion-system.md",
             "children": []
-          },
+          }
         ]
       },
       {
@@ -351,7 +354,5 @@
         ]
       }
     ]
-  },
-  "publishSpace": true,
-  "docsPath": "docs/"
+  }
 }

--- a/docs/cpu-software/How-to-build-linux-image.md
+++ b/docs/cpu-software/How-to-build-linux-image.md
@@ -143,5 +143,5 @@ The full-disk OS images are stored in:
 * **Linux and macOS:** `flipperone-linux-build-scripts/out/images`. 
 * **Windows 10/11:** `Linux/Debian/home/[wsl user]/flipperone-linux-build-scripts/out/images`.
 
-You can now [install the image to your board](How-to-install-an-image.md).
+You can now [install the image to your board](./How-to-install-linux-image.md).
 :::

--- a/docs/cpu-software/rk3576-mainlining.md
+++ b/docs/cpu-software/rk3576-mainlining.md
@@ -10,7 +10,7 @@ We use the Rockchip RK3576 system-on-chip for our main application processor, wh
 
 ## Why we chose RK3576:
 * Performance: comparable to Raspberry Pi 5
-* Energy efficiency: <1W idle, around 4W under heavy load, stated TDP of 10W
+* Energy efficiency: \<1W idle, around 4W under heavy load, stated TDP of 10W
 * Up-to-date architecture and peripheral standards: UFS storage, Vulkan support, built-in neural engine, modern HDMI/DP display compatibility, etc.
 * Existing support in upstream Linux, U-boot, and TF-A at least at some usable level
 

--- a/docs/general/Controls.md
+++ b/docs/general/Controls.md
@@ -59,8 +59,7 @@ This page describes the controls of Flipper One — the buttons, touchpad, and D
       <p><img src="https://api.archbee.com/api/optimize/3StCFqarJkJQZV-7N79yY/rDgkRg_dF9IFOgihFVzjh-20260122-124532.svg" alt=""></p>
     </td>
     <td align="left" colSpan="1" rowSpan="1">
-      <p>Adaptive App-Defined Button. Current action is context dependent and displayed on screen above the button.
-      </p>
+      <p>Adaptive App-Defined Button. Current action is context dependent and displayed on screen above the button.</p>
       <p><strong>Recommended UI actions:</strong> more, edit, extra, config, rename.</p>
       <p>‎</p>
     </td>

--- a/docs/resources/Markup-example.md
+++ b/docs/resources/Markup-example.md
@@ -147,22 +147,21 @@ Flipper One documentation supports headings H1–H3.
 To control whether a link opens in a new tab — and to write short relative hrefs for in-docs links — use Archbee's `:Link[]` directive instead of plain Markdown.
 
 **External link (new tab):**
-
-`:Link[label]{href="https://example.com" newTab="true" hasDisabledNofollow="false"}`
-
-‎ 
+```markdown
+:Link[label]{href="https://example.com" newTab="true" hasDisabledNofollow="false"}
+```
 
 **Same-page anchor (same tab):**
 
-`:Link[label]{href="./#section-name" newTab="false" hasDisabledNofollow="true"}`
-
-‎ 
+```markdown
+:Link[label]{href="./#section-name" newTab="false" hasDisabledNofollow="true"}
+```
 
 **Another page in the docs (optional anchor):**
 
-`:Link[label]{href="<relative-path>.md#section-name" newTab="true" hasDisabledNofollow="true"}`
-
-‎ 
+```markdown
+:Link[label]{href="<relative-path>.md#section-name" newTab="true" hasDisabledNofollow="true"}
+```
 
 Use a path relative to the current file:
 
@@ -171,8 +170,6 @@ Use a path relative to the current file:
 - `../folder/Other-Page.md` — file in a sibling folder
 
 The `#section-name` anchor is optional. Anchor IDs are derived from the heading text (lowercased, spaces replaced with hyphens).
-
-‎ 
 
 <table isTableHeaderOn="true" columnWidths="141,522">
   <tr>
@@ -338,17 +335,12 @@ Caption
   <tr>
     <td>
       <ul>
-      <li>Item A
-      <ul>
-      <li>Nested A.1</li>
-      </ul>
-      </li>
-      <li>Item B</li>
+        <li>Item A</li>
+        <li>Item B</li>
       </ul>
     </td>
     <td>
       <p><code>- Item A</code></p>
-      <p><code>  - Nested A.1</code></p>
       <p><code>- Item B</code></p>
     </td>
   </tr>


### PR DESCRIPTION
Part of #138 (1/2)

This pull request adds a CI pipeline that makes the following tests:

- The documentation configuration (archbee.js) and document structure are valid and can be built using `archbee dev` without errors.
- Links in the documentation are valid (no 404 or other bad codes).

I recommend making this check mandatory for all PRs in this repository.

-- 

Testing on a PR in my fork.

- Just the pipeline: build [runs and fails](https://github.com/NickVolynkin/flipperone-docs/actions/runs/26394586227/job/77692118957) on `archbee validate`.
- Validate-related fixes: build [runs](https://github.com/NickVolynkin/flipperone-docs/actions/runs/26394905026/job/77693162687), succeeds on `archbee validate` and fails on `archbee broken-links`.
- Link-related fixes: build [runs and succeeds](https://github.com/NickVolynkin/flipperone-docs/actions/runs/26394952478/job/77693316313). 