### PR TITLE
docs(testing/Network): fix English-spelling typos (Usally, simultanious, Bleutooth)

### DIFF
--- a/docs/testing/Network.md
+++ b/docs/testing/Network.md
@@ -26,12 +26,12 @@ Classic Wi-Fi access point mode used in Wi-Fi routers. *Can we use different ban
 
 ### Client (station) mode
 
-Client (STA) mode, where device connects to Wi-Fi access point. Usally laptops and smartphones are Wi-Fi clients. We need to test simultanious work AP and STA modes on different and same bands
+Client (STA) mode, where device connects to Wi-Fi access point. Usually laptops and smartphones are Wi-Fi clients. We need to test simultaneous work AP and STA modes on different and same bands
 
 1. Connect to Wi-Fi access point as client&#x20;
 2. Mease speed with `iperf3`&#x20;
 3. Repeat test on all bands (2,4 GHz, 5 GHz, 6 GHz)
-4. Test simultanious work with AP mode
+4. Test simultaneous work with AP mode
 
 ### Monitor mode
 
@@ -47,7 +47,7 @@ Perform RSN PMKID sniff from real access point.
 
 # Bluetooth
 
-Our Bleutooth and Bluetooth Low Energy are integrated in Wi-Fi chip.&#x20;
+Our Bluetooth and Bluetooth Low Energy are integrated in Wi-Fi chip.&#x20;
 
 ### Bluetooth Speaker (master)&#x20;
 


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

I read https://blog.flipper.net/flipper-one-we-need-your-help/ and
wanted to send something small and clearly helpful while you focus on
the harder parts. Happy to do more in the same spirit if useful, and
genuinely happy to be closed otherwise.

## What

Fixes four English-spelling typos in `docs/testing/Network.md`, all on the same page:

- L29: `Usally` → `Usually`
- L29: `simultanious` → `simultaneous`
- L34: `simultanious` → `simultaneous`
- L50: `Bleutooth` → `Bluetooth` (the very next paragraph spells it correctly as "Bluetooth", so this one is self-evidently inconsistent)

Single file. No content/structure changes. No reformatting of unrelated lines.

## Why

This is the page on the Developer Portal that contributors land on when looking at Wi-Fi / Bluetooth testing for Flipper One. With the wider community now being invited to help test the MT7921AUN chipset, the misspellings make the testing-procedure docs read as rougher than they actually are. Each substitution is unambiguous — no judgment calls about hardware, networking, or testing methodology.

I intentionally did NOT touch other items on the same page that might be intentional:

- `Mease speed with iperf3` on L28 — almost certainly `Measure`, but it's adjacent to the typos above and I wanted to keep this PR strictly to "obvious English-spelling mistakes a spell-checker would flag". Happy to send a follow-up if you want it included.

## How verified

- `git diff` shows only the four substitutions.
- Each typo was flagged by `codespell` and manually re-read in context.
- The `Bleutooth` fix is self-confirming: the same sentence then uses `Bluetooth` correctly.

## Maintainer note

Feel free to close this with zero ceremony if a docs-typo PR isn't useful right now — I know the team is small and the focus is on harder parts. I won't open follow-up PRs in this repo unless you signal it's welcome.
