### PR TITLE
docs(general/Controls): fix typos in Full Power Cycle row (complety, quicly)

### DIFF
--- a/docs/general/Controls.md
+++ b/docs/general/Controls.md
@@ -169,7 +169,7 @@ Some buttons and their combinations have hardware-defined behavior that does not
       (Hardware Reboot)</strong></p>
     </td>
     <td align="left">
-      <p>Hold <code>Power</code> button for 10 seconds to complety power cycle device. It will quicly turn off and on battery.</p>
+      <p>Hold <code>Power</code> button for 10 seconds to completely power cycle device. It will quickly turn off and on battery.</p>
       <p>What will happen when USB charger connected?</p>
       <p>‎</p>
     </td>


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

I read https://blog.flipper.net/flipper-one-we-need-your-help/ and
wanted to send something small and clearly helpful while you focus on
the harder parts. Happy to do more in the same spirit if useful, and
genuinely happy to be closed otherwise.

## What

Fixes two English-spelling typos on a single line of `docs/general/Controls.md`, inside the "Full Power Cycle (Hardware Reboot)" row of the controls reference table:

- `complety` → `completely`
- `quicly` → `quickly`

Single line, single file. No content/structure changes. No table reformatting.

## Why

`general/Controls.md` is the user-facing controls reference page on the Developer Portal — it describes what every button does and how the device boots. The "Full Power Cycle" row is a procedure users actually follow, so two side-by-side adverbial typos here read as rougher than the rest of the page. The substitutions are unambiguous (both are misspellings of common English adverbs, both have correct forms within easy reach in the same sentence).

I deliberately did not touch the row's surrounding `<table>` markup or any other rows in the file.

## How verified

- `git diff` shows a single hunk, single line, two single-word substitutions.
- Re-read the row twice; the intent is preserved exactly.
- No code, no behavioral change, no surrounding markup touched.

## Maintainer note

Feel free to close this with zero ceremony if a docs-typo PR isn't useful right now. The team has bigger things to focus on, and I'll take "no" gracefully.
