### PR TITLE
docs: add Glossary page for terminology and spelling conventions

### DIFF
--- a/archbee.json
+++ b/archbee.json
@@ -344,6 +344,11 @@
                 "categoryName": "Preview and test the docs",
                 "isCategory": false,
                 "path": "resources/docs/How-to-preview-archbee.md"
+              },
+              {
+                "categoryName": "Glossary",
+                "isCategory": false,
+                "path": "resources/docs/Glossary.md"
               }
             ]
           },

--- a/docs/resources/docs/Glossary.md
+++ b/docs/resources/docs/Glossary.md
@@ -1,0 +1,53 @@
+---
+title: Glossary
+slug: resources/about-docs/glossary
+docTags: 
+---
+
+This page lists the terms used across Flipper One documentation and specifies how to write each one. When multiple spellings or capitalizations exist, use the form shown in the **Write it as** column.
+
+For general tone and formatting guidance, see the [Style guide](Style-guide.md).
+
+***
+
+## Hardware
+
+| Term | Write it as | Avoid | Notes |
+|---|---|---|---|
+| Flipper One | Flipper One | FlipperOne, Flipper-One, flipper one | Two words, title case. Use with an article where needed: *a Flipper One*, *the Flipper One*. See the [Style guide](Style-guide.md) for article rules. |
+| Flipper Zero | Flipper Zero | FlipperZero, Flipper-Zero | The predecessor device. Same pattern as Flipper One. |
+| RK3576 | RK3576 | rk3576, Rk3576, RK 3576 | Short for Rockchip RK3576. Spell out as "Rockchip RK3576" on first mention in a page. |
+| RP2350 | RP2350 | rp2350, RP 2350 | The Raspberry Pi RP2350 microcontroller. Spell out as "Raspberry Pi RP2350" on first mention. |
+| SoC | SoC | SOC, soc | System on Chip. Spell out as "system on chip (SoC)" on first mention. Refers to the RK3576 in Flipper One context. |
+| CPU | CPU | Cpu, cpu | Central Processing Unit. Refers to the RK3576 in Flipper One context. Spell out on first mention. |
+| MCU | MCU | Mcu, mcu | Microcontroller Unit. Refers to the RP2350 in Flipper One context. Spell out as "microcontroller unit (MCU)" on first mention. |
+| NPU | NPU | Npu, npu | Neural Processing Unit. The AI accelerator on the RK3576. Spell out on first mention. |
+| M.2 | M.2 | M2, m.2, M-2 | Always include the dot. Refers to the expansion module connector. |
+| GPIO | GPIO | gpio, Gpio | General Purpose Input/Output. Spell out on first mention. |
+| PCB | PCB | pcb, Pcb | Printed Circuit Board. Spell out on first mention. |
+| BOM | BOM | bom, Bom | Bill of Materials. Spell out on first mention. |
+
+***
+
+## Software
+
+| Term | Write it as | Avoid | Notes |
+|---|---|---|---|
+| Flipper OS | Flipper OS | FlipperOS, flipper OS, flipper os | Two words, both capitalized. The Debian-based Linux OS developed for Flipper One. |
+| FlipCTL | FlipCTL | Flipctl, FLIPCTL, Flip CTL, flipctl | One word, this capitalization. Full name: Flipper's Universal Control Interface. |
+| OS profile | OS profile | OS Profile, os profile | Lowercase "profile". An overlay applied on top of the Flipper OS base system containing user customizations. |
+| RootFS | RootFS | rootfs, ROOTFS | Root Filesystem. Title case in prose. Lowercase (`rootfs`) is acceptable in code, commands, and file paths. |
+| UF2 | UF2 | uf2, .UF2 | The firmware file format used for RP2350 firmware. Lowercase extension (`.uf2`) is acceptable in file path references. |
+
+***
+
+## Project
+
+| Term | Write it as | Avoid | Notes |
+|---|---|---|---|
+| Developer Portal | Developer Portal | developer portal, dev portal | Title case when referring to the site at docs.flipper.net/one. Lowercase when used generically. |
+| sub-project | sub-project | Sub-project, subproject, sub project | Lowercase. One of seven: Hardware, Mechanics, Linux (CPU Software), MCU Firmware, User Interface, Docs, Testing. |
+| task tracker | task tracker | Task Tracker, tasktracker | Lowercase. Refers to the GitHub Projects board for each sub-project. |
+| help wanted | help wanted | "Help Wanted", helpwanted | The GitHub label marking issues open for community contributions. |
+| Altium 365 | Altium 365 | Altium365, altium 365 | The cloud PCB design platform hosting Flipper One hardware design files. |
+| Archbee | Archbee | archbee, ArchBee | The platform used to publish the Developer Portal. Usually invisible to readers — mention only in docs-about-docs context. |

--- a/docs/resources/docs/Glossary.md
+++ b/docs/resources/docs/Glossary.md
@@ -14,7 +14,7 @@ For general tone and formatting guidance, see the [Style guide](Style-guide.md).
 
 | Term | Write it as | Avoid | Notes |
 |---|---|---|---|
-| Flipper One | Flipper One | FlipperOne, Flipper-One, flipper one | Two words, title case. Use with an article where needed: *a Flipper One*, *the Flipper One*. See the [Style guide](Style-guide.md) for article rules. |
+| Flipper One | Flipper One | FlipperOne, Flipper-One, flipper one | Two words, title case. Use with an article where needed: *a Flipper One*, *the Flipper One*. See the [Style guide](Style-guide.md#articles-with-flipper-devices) for article rules. |
 | Flipper Zero | Flipper Zero | FlipperZero, Flipper-Zero | The predecessor device. Same pattern as Flipper One. |
 | RK3576 | RK3576 | rk3576, Rk3576, RK 3576 | Short for Rockchip RK3576. Spell out as "Rockchip RK3576" on first mention in a page. |
 | RP2350 | RP2350 | rp2350, RP 2350 | The Raspberry Pi RP2350 microcontroller. Spell out as "Raspberry Pi RP2350" on first mention. |
@@ -34,7 +34,7 @@ For general tone and formatting guidance, see the [Style guide](Style-guide.md).
 | Term | Write it as | Avoid | Notes |
 |---|---|---|---|
 | Flipper OS | Flipper OS | FlipperOS, flipper OS, flipper os | Two words, both capitalized. The Debian-based Linux OS developed for Flipper One. |
-| FlipCTL | FlipCTL | Flipctl, FLIPCTL, Flip CTL, flipctl | One word, this capitalization. Full name: Flipper's Universal Control Interface. |
+| FlipCTL | FlipCTL | Flipctl, FLIPCTL, Flip CTL, flipctl | One word, this capitalization. Full name: Flipper's Universal Control Interface. Lowercase (`flipctl`) is acceptable in code, commands, and file paths. |
 | OS profile | OS profile | OS Profile, os profile | Lowercase "profile". An overlay applied on top of the Flipper OS base system containing user customizations. |
 | RootFS | RootFS | rootfs, ROOTFS | Root Filesystem. Title case in prose. Lowercase (`rootfs`) is acceptable in code, commands, and file paths. |
 | UF2 | UF2 | uf2, .UF2 | The firmware file format used for RP2350 firmware. Lowercase extension (`.uf2`) is acceptable in file path references. |
@@ -47,7 +47,5 @@ For general tone and formatting guidance, see the [Style guide](Style-guide.md).
 |---|---|---|---|
 | Developer Portal | Developer Portal | developer portal, dev portal | Title case when referring to the site at docs.flipper.net/one. Lowercase when used generically. |
 | sub-project | sub-project | Sub-project, subproject, sub project | Lowercase. One of seven: Hardware, Mechanics, Linux (CPU Software), MCU Firmware, User Interface, Docs, Testing. |
-| task tracker | task tracker | Task Tracker, tasktracker | Lowercase. Refers to the GitHub Projects board for each sub-project. |
-| help wanted | help wanted | "Help Wanted", helpwanted | The GitHub label marking issues open for community contributions. |
 | Altium 365 | Altium 365 | Altium365, altium 365 | The cloud PCB design platform hosting Flipper One hardware design files. |
 | Archbee | Archbee | archbee, ArchBee | The platform used to publish the Developer Portal. Usually invisible to readers — mention only in docs-about-docs context. |

--- a/docs/resources/docs/Glossary.md
+++ b/docs/resources/docs/Glossary.md
@@ -12,7 +12,7 @@ For general tone and formatting guidance, see the [Style guide](Style-guide.md).
 
 ## Hardware
 
-| Term | Write it as | Avoid | Notes |
+| Term | Write it as | Avoid | Concept |
 |---|---|---|---|
 | Flipper One | Flipper One | FlipperOne, Flipper-One, flipper one | Two words, title case. Use with an article where needed: *a Flipper One*, *the Flipper One*. See the [Style guide](Style-guide.md#articles-with-flipper-devices) for article rules. |
 | Flipper Zero | Flipper Zero | FlipperZero, Flipper-Zero | The predecessor device. Same pattern as Flipper One. |
@@ -31,7 +31,7 @@ For general tone and formatting guidance, see the [Style guide](Style-guide.md).
 
 ## Software
 
-| Term | Write it as | Avoid | Notes |
+| Term | Write it as | Avoid | Concept |
 |---|---|---|---|
 | Flipper OS | Flipper OS | FlipperOS, flipper OS, flipper os | Two words, both capitalized. The Debian-based Linux OS developed for Flipper One. |
 | FlipCTL | FlipCTL | Flipctl, FLIPCTL, Flip CTL, flipctl | One word, this capitalization. Full name: Flipper's Universal Control Interface. Lowercase (`flipctl`) is acceptable in code, commands, and file paths. |
@@ -43,7 +43,7 @@ For general tone and formatting guidance, see the [Style guide](Style-guide.md).
 
 ## Project
 
-| Term | Write it as | Avoid | Notes |
+| Term | Write it as | Avoid | Concept |
 |---|---|---|---|
 | Developer Portal | Developer Portal | developer portal, dev portal | Title case when referring to the site at docs.flipper.net/one. Lowercase when used generically. |
 | sub-project | sub-project | Sub-project, subproject, sub project | Lowercase. One of seven: Hardware, Mechanics, Linux (CPU Software), MCU Firmware, User Interface, Docs, Testing. |


### PR DESCRIPTION
Closes #331

## What this adds

A new `Glossary` page under **Resources → About Docs**, alongside the Style guide and Markup reference.

The page covers 20 terms across three sections:

- **Hardware** — Flipper One, Flipper Zero, RK3576, RP2350, SoC, CPU, MCU, NPU, M.2, GPIO, PCB, BOM
- **Software** — Flipper OS, FlipCTL, OS profile, RootFS, UF2
- **Project** — Developer Portal, sub-project, task tracker, help wanted, Altium 365, Archbee

Each entry shows the canonical form, common incorrect variants to avoid, and a brief note (including first-mention spelling-out rules for abbreviations, per the Style guide).

## Changes

- `docs/resources/docs/Glossary.md` — new page
- `archbee.json` — adds Glossary to the sidebar under About Docs