### PR TITLE
docs(Open-tasks): fix doubled "and"

### DIFF
--- a/docs/Open-tasks.md
+++ b/docs/Open-tasks.md
@@ -192,7 +192,7 @@ User interface design: operating modes, on-screen graphics, device prints, and F
   <tr>
     <td align="left" colSpan="1" rowSpan="1">
       <p>🟢 <a href="https://github.com/flipperdevices/flipperone-ui/issues/1">Describe operating modes + draw scheme</a></p>
-      <p>We need to describe and and name all operating modes</p>
+      <p>We need to describe and name all operating modes</p>
     </td>
     <td align="center" colSpan="1" rowSpan="1">
       <p>💬 28</p>


### PR DESCRIPTION
<!--
  Canonical 2-line preamble. Single source of truth — every PR body
  opens with this verbatim. Composer is substituted at PR-craft time.
-->

> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `and and` → `and` in `docs/Open-tasks.md`.
