### PR TITLE
ci: automated per-PR documentation previews on GitHub Pages

### DIFF
--- a/.github/workflows/docs-preview-build.yml
+++ b/.github/workflows/docs-preview-build.yml
@@ -1,0 +1,83 @@
+# PR preview, stage 1 of 2: build (untrusted).
+#
+# Runs on `pull_request`, so for fork PRs it executes the contributor's
+# content with a read-only GITHUB_TOKEN and no access to secrets — the only
+# safe place to run untrusted markdown through the toolchain. It renders the
+# docs into a static, script-free HTML snapshot and uploads it as an
+# artifact. It deliberately CANNOT deploy or comment: that needs write
+# permissions, which fork PRs must never get (this is also why none of this
+# uses `pull_request_target` with a checkout of PR code — that combination
+# hands the contributor a write token).
+#
+# Stage 2 (docs-preview-deploy.yml) runs in the trusted base-repo context on
+# `workflow_run`, downloads the artifact, and publishes it to GitHub Pages.
+
+name: Docs preview build
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "archbee.json"
+      - "tools/preview/**"
+      - ".github/workflows/docs-preview-build.yml"
+
+permissions:
+  contents: read
+
+# A new push to the same PR supersedes the previous build.
+concurrency:
+  group: docs-preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Default checkout for pull_request is the merge commit: the preview
+      # shows the PR as it would look merged into public-release.
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: tools/preview/package-lock.json
+
+      - name: Install Archbee CLI
+        run: npm install --global @archbee/cli
+
+      - name: Install snapshot tool dependencies
+        run: npm ci
+        working-directory: tools/preview
+
+      # Renders every page of the Archbee dev server in headless Chrome
+      # (preinstalled on ubuntu runners) and saves static HTML. All <script>
+      # tags and inline handlers are stripped, so the artifact contains no
+      # executable JS from the PR. See tools/preview/snapshot.mjs.
+      - name: Build static preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          node tools/preview/snapshot.mjs \
+            --out preview-out/site \
+            --banner "Docs preview: PR #${PR_NUMBER} @ ${HEAD_SHA:0:7}"
+
+      # The deploy workflow needs to know which PR this artifact belongs to.
+      # It treats this file as untrusted input and cross-checks it against
+      # the GitHub API before publishing.
+      - name: Record PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: printf '%s\n' "$PR_NUMBER" > preview-out/pr-number.txt
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-preview
+          path: preview-out
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,0 +1,81 @@
+# PR preview: remove the published preview when a PR is closed.
+#
+# Uses `pull_request_target` because fork PRs need it: the plain
+# `pull_request` closed event runs with a read-only GITHUB_TOKEN for forks
+# and could not delete from gh-pages. `pull_request_target` is safe HERE —
+# and only here — because this workflow never checks out or executes
+# anything from the PR; it only runs base-repo code against the gh-pages
+# branch. Do not add a checkout of the PR head to this file.
+
+name: Docs preview cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cleanup:
+    if: github.repository == 'flipperdevices/flipperone-docs'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Remove pr/<n> from gh-pages
+        id: rm
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if ! git fetch --depth 1 origin gh-pages; then
+            echo "No gh-pages branch — nothing to clean up."
+            exit 0
+          fi
+          git switch -c gh-pages FETCH_HEAD
+          if [[ ! -e "pr/${PR_NUMBER}" ]]; then
+            echo "No preview for PR #${PR_NUMBER} — nothing to clean up."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm -r --quiet "pr/${PR_NUMBER}"
+          git commit -m "Remove preview for PR #${PR_NUMBER}"
+          # Shallow history: on a push race, redo the removal on the new tip
+          # instead of rebasing.
+          for _ in 1 2 3; do
+            git push origin HEAD:gh-pages && { echo "removed=true" >> "$GITHUB_OUTPUT"; exit 0; }
+            git fetch --depth 1 origin gh-pages
+            git reset --hard FETCH_HEAD
+            if [[ ! -e "pr/${PR_NUMBER}" ]]; then
+              echo "Preview already removed."
+              echo "removed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            git rm -r --quiet "pr/${PR_NUMBER}"
+            git commit -m "Remove preview for PR #${PR_NUMBER}"
+          done
+          echo "::error::could not push gh-pages after 3 attempts"
+          exit 1
+
+      - name: Mark the preview comment as expired
+        if: steps.rm.outputs.removed == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request.number;
+            const marker = '<!-- docs-preview-comment -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pr, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id,
+                body: `${marker}\n### 📖 Docs preview\n\nThe PR was closed and its preview has been removed.`,
+              });
+            }

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -1,0 +1,182 @@
+# PR preview, stage 2 of 2: deploy (trusted).
+#
+# Triggered by the completion of "Docs preview build" via `workflow_run`.
+# This workflow always runs the code from public-release, never the PR's,
+# so it is safe to give it write permissions. The only inputs taken from
+# the untrusted build are (a) the rendered HTML, which is published as-is
+# to GitHub Pages, and (b) the PR number, which is validated and then
+# cross-checked against the GitHub API before anything is written.
+#
+# The published HTML is static and script-free (the build strips <script>
+# and inline handlers): github.io project Pages of one org share a single
+# browser origin, so untrusted JS there could script against other
+# previews. Hosting untrusted *markup* on github.io — never on
+# docs.flipper.net — keeps the blast radius at "an ugly page".
+#
+# Maintainers: this needs GitHub Pages enabled once, with
+# "Deploy from a branch" -> gh-pages / (root). The branch is created
+# automatically on first deploy.
+
+name: Docs preview deploy
+
+on:
+  workflow_run:
+    workflows: ["Docs preview build"]
+    types: [completed]
+
+permissions:
+  contents: write       # push to gh-pages
+  pull-requests: write  # sticky preview comment
+  pages: read           # resolve the Pages URL for the comment
+
+jobs:
+  deploy:
+    # Guard against running in forks of this repo (their gh-pages would get
+    # spammed) and only deploy successful PR builds.
+    if: >-
+      github.repository == 'flipperdevices/flipperone-docs' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download preview artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-preview
+          path: preview-out
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # The artifact was produced by untrusted code, so the PR number in it
+      # could be anything. Accept it only if it is a plain number and the
+      # API confirms that PR's head SHA matches the commit this workflow_run
+      # was triggered for — an attacker cannot point their artifact at
+      # somebody else's PR.
+      - name: Validate PR number against the API
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          pr="$(tr -cd '0-9' < preview-out/pr-number.txt)"
+          [[ -n "$pr" ]] || { echo "::error::artifact carries no PR number"; exit 1; }
+          api="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq '{sha: .head.sha, state: .state}')"
+          head_sha="$(jq -r .sha <<< "$api")"
+          state="$(jq -r .state <<< "$api")"
+          if [[ "$head_sha" != "$RUN_HEAD_SHA" ]]; then
+            echo "::error::PR #${pr} head ${head_sha} does not match run head ${RUN_HEAD_SHA}"
+            exit 1
+          fi
+          if [[ "$state" != "open" ]]; then
+            echo "PR #${pr} is ${state}; skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "number=${pr}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout gh-pages
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          path: gh-pages
+          # The branch may not exist yet; fetch the default branch then and
+          # switch to an orphan gh-pages below.
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Publish to gh-pages/pr/<n>
+        if: steps.pr.outputs.skip != 'true'
+        working-directory: gh-pages
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git fetch --depth 1 origin gh-pages; then
+            git switch -c gh-pages FETCH_HEAD
+          else
+            # First deploy ever: start an empty branch. switch --orphan keeps
+            # the old working tree around as untracked files — drop them so
+            # the docs sources don't get committed into gh-pages.
+            git switch --orphan gh-pages
+            git clean -fdx
+          fi
+          stage_preview() {
+            rm -rf "pr/${PR_NUMBER}"
+            mkdir -p "pr/${PR_NUMBER}"
+            cp -R ../preview-out/site/. "pr/${PR_NUMBER}/"
+            # Pages must serve _next/ CSS paths verbatim — disable Jekyll.
+            touch .nojekyll
+            git add -A
+          }
+          stage_preview
+          if git diff --cached --quiet; then
+            echo "Preview unchanged — nothing to push."
+            exit 0
+          fi
+          git commit -m "Preview for PR #${PR_NUMBER}"
+          # Another preview may push between our fetch and push. The history
+          # is shallow, so instead of rebasing, redo the staging on top of
+          # the new tip and try again.
+          for _ in 1 2 3; do
+            git push origin HEAD:gh-pages && exit 0
+            git fetch --depth 1 origin gh-pages
+            git reset --hard FETCH_HEAD
+            stage_preview
+            if git diff --cached --quiet; then
+              echo "Preview already up to date."
+              exit 0
+            fi
+            git commit -m "Preview for PR #${PR_NUMBER}"
+          done
+          echo "::error::could not push gh-pages after 3 attempts"
+          exit 1
+
+      - name: Comment preview link on the PR
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const pr = Number(process.env.PR_NUMBER);
+            const sha = process.env.HEAD_SHA;
+            const { owner, repo } = context.repo;
+
+            // Prefer the real Pages URL (handles custom domains); fall back
+            // to the default github.io address if Pages is not enabled yet.
+            let base = `https://${owner}.github.io/${repo}/`;
+            let pagesNote = '';
+            try {
+              const pages = await github.request('GET /repos/{owner}/{repo}/pages', { owner, repo });
+              base = pages.data.html_url;
+            } catch {
+              pagesNote = '\n\n> [!NOTE]\n> GitHub Pages is not enabled for this repository yet, so the link ' +
+                'above will 404. A maintainer can enable it under Settings → Pages → ' +
+                'Deploy from a branch → `gh-pages` / `(root)`.';
+            }
+            const url = `${base.replace(/\/?$/, '/')}pr/${pr}/`;
+
+            const marker = '<!-- docs-preview-comment -->';
+            const body = [
+              marker,
+              `### 📖 Docs preview`,
+              '',
+              `**${url}**`,
+              '',
+              `Built from ${sha} — updated on every push. The preview is a static, script-free`,
+              `snapshot: search and other interactive features are disabled, and images that live`,
+              `on Archbee's CDN are loaded from production.`,
+              pagesNote,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pr, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+            }

--- a/tools/preview/.gitignore
+++ b/tools/preview/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/preview/package-lock.json
+++ b/tools/preview/package-lock.json
@@ -1,0 +1,937 @@
+{
+  "name": "flipperone-docs-preview",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "flipperone-docs-preview",
+      "dependencies": {
+        "puppeteer-core": "^24.43.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.2.tgz",
+      "integrity": "sha512-2V5j0dOfxv3iIngIWMnW1O6UPXpeoU70HJzUJGVth/+RURhDyq7SEWTD70Y2SkUB0MQonYYWpIX3f85P/I22+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/tools/preview/package.json
+++ b/tools/preview/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "flipperone-docs-preview",
+  "private": true,
+  "type": "module",
+  "description": "Renders the Archbee docs into a static HTML snapshot for PR previews",
+  "scripts": {
+    "snapshot": "node snapshot.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "puppeteer-core": "^24.43.1"
+  }
+}

--- a/tools/preview/snapshot.mjs
+++ b/tools/preview/snapshot.mjs
@@ -1,0 +1,405 @@
+#!/usr/bin/env node
+// Render the Archbee docs into a static HTML snapshot for PR previews.
+//
+// `archbee dev` serves a client-rendered Next.js SPA: fetching a page URL
+// returns an empty shell, and the markdown is rendered in the browser.
+// There is no static-export command in the CLI, so this script starts the
+// dev server, renders every page in headless Chrome, and saves the hydrated
+// DOM as plain HTML.
+//
+// The output is deliberately static and script-free:
+//   * every <script> tag and inline on* handler is stripped, so contributor
+//     markdown cannot execute JS on the preview host (github.io is a shared
+//     origin across an org's project Pages — serving untrusted JS there
+//     would let one PR script against other previews and project sites);
+//   * all root-absolute URLs are rewritten to *relative* ones, so the
+//     snapshot works from any base path (gh-pages/pr/<n>/) without a
+//     basePath knob — the Archbee CLI has none;
+//   * same-origin assets (/_next CSS, /api/assets images) are mirrored into
+//     the output; external assets (cdn.flipper.net, api.archbee.com fonts/
+//     CDN styles) are left as absolute https URLs.
+//
+// Usage:
+//   node tools/preview/snapshot.mjs --out dist [--port 4173]
+//       [--concurrency 4] [--banner "PR #123 · abc1234"]
+//
+// Requires: @archbee/cli on PATH, Chrome/Chromium (PUPPETEER_EXECUTABLE_PATH
+// or a standard install location), puppeteer-core (npm ci in this dir).
+
+import { spawn, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer-core';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+// --- CLI args ---------------------------------------------------------------
+const args = process.argv.slice(2);
+function arg(name, dflt) {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : dflt;
+}
+const outDir = path.resolve(arg('out', 'preview-dist'));
+const port = Number(arg('port', '4173'));
+const concurrency = Number(arg('concurrency', '4'));
+const banner = arg('banner', '');
+// The dev server advertises (and the SPA generates asset URLs against)
+// http://localhost:<port>, so render through the same host name — otherwise
+// the in-page URL rewriting would see those URLs as cross-origin.
+const origin = `http://localhost:${port}`;
+
+// --- Page enumeration -------------------------------------------------------
+// The dev server routes pages by file path relative to docs/, without the
+// .md extension and case-sensitive (docs/general/Tech-Specs.md ->
+// /general/Tech-Specs). Frontmatter slugs are NOT used by the dev server.
+function listRoutes(dir, prefix = '') {
+  const routes = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isDirectory()) {
+      if (entry.name === 'files') continue; // assets, not pages
+      routes.push(...listRoutes(path.join(dir, entry.name), `${prefix}${entry.name}/`));
+    } else if (entry.name.endsWith('.md')) {
+      routes.push(prefix + entry.name.slice(0, -3));
+    }
+  }
+  return routes;
+}
+const routes = listRoutes(path.join(repoRoot, 'docs'));
+// Sidebar order from archbee.json, used to pick category landing pages.
+const archbeeConfig = JSON.parse(fs.readFileSync(path.join(repoRoot, 'archbee.json'), 'utf8'));
+const orderedRoutes = [];
+(function walk(nodes) {
+  for (const n of nodes ?? []) {
+    if (n.path) orderedRoutes.push(n.path.replace(/\.md$/, ''));
+    walk(n.children);
+  }
+})(archbeeConfig.structure?.docsTree);
+if (routes.length === 0) {
+  console.error('No markdown pages found under docs/');
+  process.exit(1);
+}
+const readme = archbeeConfig.structure?.readme?.replace(/\.md$/, '') ?? routes[0];
+console.log(`Found ${routes.length} pages; landing page: ${readme}`);
+
+// --- Start archbee dev ------------------------------------------------------
+// Refuse to reuse a server that is already squatting the port: it may serve
+// different content (stale checkout, another working copy).
+try {
+  await fetch(origin + '/', { redirect: 'manual' });
+  console.error(`Port ${port} is already in use — stop the other server or pass a different --port.`);
+  process.exit(1);
+} catch { /* free, good */ }
+console.log(`Starting archbee dev on :${port} ...`);
+// detached: own process group, so stopDev can kill the whole tree —
+// the CLI wraps a next-server child that would otherwise outlive it.
+const dev = spawn('archbee', ['dev', '--port', String(port)], {
+  cwd: repoRoot,
+  stdio: ['ignore', 'pipe', 'pipe'],
+  detached: true,
+  env: { ...process.env, BROWSER: 'none', CI: 'true' },
+});
+let devLog = '';
+dev.stdout.on('data', d => { devLog += d; });
+dev.stderr.on('data', d => { devLog += d; });
+dev.on('exit', code => {
+  if (!shuttingDown) {
+    console.error(`archbee dev exited early (code ${code}):\n${devLog}`);
+    process.exit(1);
+  }
+});
+let shuttingDown = false;
+function stopDev() {
+  shuttingDown = true;
+  try { process.kill(-dev.pid, 'SIGTERM'); } catch { /* already gone */ }
+  try { dev.kill('SIGTERM'); } catch { /* already gone */ }
+}
+process.on('exit', stopDev);
+
+async function waitForServer(timeoutMs = 120000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(origin + '/', { redirect: 'manual' });
+      if (res.status > 0) return;
+    } catch { /* not up yet */ }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  console.error(`archbee dev did not become ready in ${timeoutMs / 1000}s:\n${devLog}`);
+  process.exit(1);
+}
+await waitForServer();
+console.log('Dev server is up.');
+
+// --- Browser ----------------------------------------------------------------
+function findChrome() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) return process.env.PUPPETEER_EXECUTABLE_PATH;
+  for (const p of [
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+  ]) {
+    if (fs.existsSync(p)) return p;
+  }
+  try { return execSync('command -v google-chrome chromium', { encoding: 'utf8' }).split('\n')[0]; } catch { /* fallthrough */ }
+  console.error('No Chrome/Chromium found; set PUPPETEER_EXECUTABLE_PATH.');
+  process.exit(1);
+}
+const browser = await puppeteer.launch({
+  executablePath: findChrome(),
+  headless: 'new',
+  args: ['--no-sandbox', '--disable-dev-shm-usage'],
+});
+
+// --- In-page sanitize + rewrite ----------------------------------------------
+// Runs in the browser after hydration. `routeSet` distinguishes doc links
+// (rewritten to <rel>/Route/ directory URLs) from asset paths.
+function sanitizeAndRewrite(depth, routeList, bannerText) {
+  const rel = depth === 0 ? './' : '../'.repeat(depth);
+  const routeSet = new Set(routeList);
+  const assets = new Set();
+  const categories = new Set();
+
+  const toLocal = (url) => {
+    // returns {href, asset} for a root-absolute same-origin URL, else null
+    let u;
+    try { u = new URL(url, location.href); } catch { return null; }
+    if (u.origin !== location.origin) return null;
+    const p = u.pathname.replace(/^\//, '');
+    const pBare = decodeURIComponent(p.replace(/\/$/, ''));
+    if (p === '' || routeSet.has(pBare)) {
+      return { href: rel + (pBare ? pBare + '/' : '') + u.hash, asset: null };
+    }
+    // Category link (e.g. /hardware/): the SPA 404s on these, the snapshot
+    // gets a redirect index.html to the category's first page instead.
+    if (pBare && routeList.some(r => r.startsWith(pBare + '/'))) {
+      categories.add(pBare);
+      return { href: rel + pBare + '/' + u.hash, asset: null };
+    }
+    if (p.startsWith('api/assets/')) {
+      const ap = 'assets/' + decodeURIComponent(p.slice('api/assets/'.length));
+      assets.add(u.pathname + u.search + '\u0000' + ap);
+      return { href: rel + ap, asset: ap };
+    }
+    // _next CSS, favicons, anything else same-origin: mirror by path
+    assets.add(u.pathname + u.search + '\u0000' + decodeURIComponent(p));
+    return { href: rel + decodeURIComponent(p), asset: p };
+  };
+
+  // 1. Drop scripts and script-ish resource hints.
+  for (const el of document.querySelectorAll('script, link[rel=preload], link[rel=modulepreload], link[rel=prefetch], link[rel=preconnect]')) el.remove();
+
+  // 2. Strip inline handlers and javascript: URLs from contributor HTML.
+  for (const el of document.querySelectorAll('*')) {
+    for (const attr of [...el.attributes]) {
+      if (/^on/i.test(attr.name)) el.removeAttribute(attr.name);
+    }
+    for (const name of ['href', 'src', 'xlink:href']) {
+      const v = el.getAttribute(name);
+      if (v && /^\s*javascript:/i.test(v)) el.setAttribute(name, '#');
+    }
+  }
+
+  // 3. Rewrite URLs.
+  for (const el of document.querySelectorAll('a[href], link[href], img[src], source[src], video[src], video[poster], audio[src], iframe[src]')) {
+    for (const name of ['href', 'src', 'poster']) {
+      const v = el.getAttribute(name);
+      if (!v) continue;
+      const r = toLocal(v);
+      if (r) el.setAttribute(name, r.href);
+    }
+  }
+  for (const el of document.querySelectorAll('img[srcset], source[srcset]')) {
+    const rewritten = el.getAttribute('srcset').split(',').map(part => {
+      const [url, ...desc] = part.trim().split(/\s+/);
+      const r = toLocal(url);
+      return [r ? r.href : url, ...desc].join(' ');
+    }).join(', ');
+    el.setAttribute('srcset', rewritten);
+  }
+
+  // 4. The app reveals <body> via JS; without scripts it would stay invisible.
+  document.body.classList.remove('opacity-0', 'transition-opacity');
+
+  // 5. Optional banner so reviewers know what they are looking at.
+  if (bannerText) {
+    const div = document.createElement('div');
+    div.textContent = bannerText + ' — static preview; search and other interactive features are disabled.';
+    div.setAttribute('style',
+      'position:sticky;top:0;z-index:9999;background:#fff3cd;color:#664d03;' +
+      'border-bottom:1px solid #ffe69c;padding:6px 12px;font:13px/1.4 sans-serif;text-align:center;');
+    document.body.prepend(div);
+  }
+
+  return { assets: [...assets], categories: [...categories] };
+}
+
+// --- Render loop --------------------------------------------------------------
+const assetMap = new Map(); // url path+query -> output path
+const categorySet = new Set(); // category prefixes that need redirect indexes
+const failures = [];
+const queue = [...routes];
+
+async function renderWorker() {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 900 });
+  for (;;) {
+    const route = queue.shift();
+    if (!route) break;
+    const depth = route.split('/').length; // page is written to <route>/index.html
+    try {
+      await page.goto(`${origin}/${route}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+      await page.waitForFunction(() => !!document.querySelector('h1'), { timeout: 30000 });
+      await new Promise(r => setTimeout(r, 1000)); // settle: client-rendered embeds/diagrams
+      const { assets, categories } = await page.evaluate(sanitizeAndRewrite, depth, routes, banner);
+      for (const pair of assets) {
+        const [urlPath, outPath] = pair.split('\u0000');
+        assetMap.set(urlPath, outPath);
+      }
+      for (const c of categories) categorySet.add(c);
+      const html = await page.content();
+      const file = path.join(outDir, route, 'index.html');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, html);
+      console.log(`  ok ${route}`);
+    } catch (err) {
+      failures.push(`${route}: ${err.message.split('\n')[0]}`);
+      console.error(`  FAIL ${route}: ${err.message.split('\n')[0]}`);
+    }
+  }
+  await page.close();
+}
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+const t0 = Date.now();
+await Promise.all(Array.from({ length: Math.min(concurrency, routes.length) }, renderWorker));
+console.log(`Rendered ${routes.length - failures.length}/${routes.length} pages in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+
+// --- Mirror same-origin assets -------------------------------------------------
+// CSS may pull in more same-origin files (fonts, images) via url(...): fetch
+// those too, rewriting the references relative to the CSS file's location.
+const assetFailures = [];
+async function mirrorAsset(urlPath, outPath) {
+  const res = await fetch(origin + urlPath);
+  if (!res.ok) {
+    assetFailures.push(`${urlPath} -> HTTP ${res.status}`);
+    return;
+  }
+  const file = path.join(outDir, outPath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  if (outPath.endsWith('.css')) {
+    let css = await res.text();
+    const cssDepth = outPath.split('/').length - 1;
+    const cssRel = cssDepth === 0 ? './' : '../'.repeat(cssDepth);
+    const extra = [];
+    css = css.replace(/url\(\s*(['"]?)(\/[^)'"]+)\1\s*\)/g, (_, q, p) => {
+      const clean = p.replace(/^\//, '').split(/[?#]/)[0];
+      extra.push([p.split('#')[0], clean]);
+      return `url(${q}${cssRel}${clean}${q})`;
+    });
+    fs.writeFileSync(file, css);
+    for (const [refPath, refOut] of extra) {
+      if (!assetMap.has(refPath) && !fs.existsSync(path.join(outDir, refOut))) {
+        assetMap.set(refPath, refOut); // picked up by the outer loop
+      }
+    }
+  } else {
+    fs.writeFileSync(file, Buffer.from(await res.arrayBuffer()));
+  }
+}
+const mirrored = new Set();
+while (mirrored.size < assetMap.size) {
+  const batch = [...assetMap].filter(([u]) => !mirrored.has(u));
+  for (const [u] of batch) mirrored.add(u);
+  await Promise.all(batch.map(([u, o]) => mirrorAsset(u, o).catch(e => assetFailures.push(`${u}: ${e.message}`))));
+}
+console.log(`Mirrored ${mirrored.size - assetFailures.length}/${mirrored.size} same-origin assets`);
+for (const f of assetFailures) console.warn(`  asset warning: ${f}`);
+
+// --- Asset completeness pass ---------------------------------------------------
+// The DOM-collected asset set can vary with render timing (lazy mounts,
+// settle windows). Scan the written HTML for local asset references and
+// fetch anything the mirror missed. /api/assets resolves docs-root-relative
+// paths with just docsPath, so the original URL is reconstructible.
+const docsPath = (archbeeConfig.docsPath ?? 'docs/').replace(/\/$/, '');
+function* htmlFiles(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) yield* htmlFiles(p);
+    else if (entry.name.endsWith('.html')) yield p;
+  }
+}
+const missing = new Map(); // site-root-relative output path -> fetch url
+for (const file of htmlFiles(outDir)) {
+  const fromDir = path.dirname(file);
+  const html = fs.readFileSync(file, 'utf8');
+  const refs = [];
+  for (const m of html.matchAll(/(?:src|href|poster)="((?:\.\.\/|\.\/)[^"]+)"/g)) refs.push(m[1]);
+  for (const m of html.matchAll(/srcset="([^"]+)"/g)) {
+    for (const part of m[1].split(',')) refs.push(part.trim().split(/\s+/)[0]);
+  }
+  for (const ref of refs) {
+    if (!/^\.\.?\//.test(ref)) continue;
+    const clean = ref.split(/[?#]/)[0];
+    const sitePath = path.relative(outDir, path.resolve(fromDir, decodeURIComponent(clean)));
+    if (sitePath.startsWith('..')) continue;
+    if (sitePath.endsWith('/') || fs.existsSync(path.join(outDir, sitePath))) continue;
+    if (fs.existsSync(path.join(outDir, sitePath, 'index.html'))) continue; // page link
+    if (sitePath.startsWith('assets/')) {
+      missing.set(sitePath, `/api/assets/${encodeURI(sitePath.slice('assets/'.length))}?docsPath=${docsPath}`);
+    } else {
+      missing.set(sitePath, '/' + encodeURI(sitePath));
+    }
+  }
+}
+let recovered = 0;
+for (const [sitePath, urlPath] of missing) {
+  try {
+    const res = await fetch(origin + urlPath);
+    if (!res.ok) {
+      console.warn(`  missing asset: ${sitePath} (${urlPath} -> HTTP ${res.status})`);
+      continue;
+    }
+    const file = path.join(outDir, sitePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, Buffer.from(await res.arrayBuffer()));
+    recovered++;
+  } catch (err) {
+    console.warn(`  missing asset: ${sitePath} (${err.message})`);
+  }
+}
+if (missing.size) console.log(`Completeness pass: recovered ${recovered}/${missing.size} referenced assets`);
+else console.log('Completeness pass: all referenced assets present');
+
+// --- Root redirect ---------------------------------------------------------------
+fs.writeFileSync(path.join(outDir, 'index.html'),
+  `<!DOCTYPE html><meta charset="utf-8"><meta http-equiv="refresh" content="0; url=${readme}/">` +
+  `<link rel="canonical" href="${readme}/"><title>Redirecting</title><a href="${readme}/">${readme}</a>\n`);
+
+// --- Category redirects -----------------------------------------------------------
+// Sidebar/category links point at directory paths the SPA cannot render;
+// redirect each to its first page in sidebar (archbee.json) order.
+for (const cat of categorySet) {
+  const target = orderedRoutes.find(r => r.startsWith(cat + '/')) ?? routes.find(r => r.startsWith(cat + '/'));
+  if (!target) continue;
+  const restRel = target.slice(cat.length + 1) + '/';
+  const file = path.join(outDir, cat, 'index.html');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file,
+    `<!DOCTYPE html><meta charset="utf-8"><meta http-equiv="refresh" content="0; url=${restRel}">` +
+    `<link rel="canonical" href="${restRel}"><title>Redirecting</title><a href="${restRel}">${target}</a>\n`);
+}
+
+// --- Done -------------------------------------------------------------------------
+await browser.close();
+stopDev();
+if (failures.length) {
+  console.error(`\n${failures.length} page(s) failed to render:`);
+  for (const f of failures) console.error(`  ${f}`);
+  process.exit(1);
+}
+console.log(`Snapshot written to ${outDir}`);
+process.exit(0);


### PR DESCRIPTION
Closes the automation gap in #340: per-PR documentation previews on GitHub Pages, no third-party services and no secrets exposed to fork PRs.

### How it works

Three workflows:

- **`docs-preview-build.yml`** (`pull_request`, paths-filtered) — renders `archbee dev` in headless Chrome and saves a static snapshot. The Archbee CLI has no static-export command and the site is a client-rendered SPA, so `tools/preview/snapshot.mjs` enumerates `docs/**/*.md`, renders each page, **strips all `<script>`/inline handlers**, rewrites absolute URLs relative (so it works under any `/pr/<n>/` subpath without a base-path knob Archbee doesn't expose), and mirrors same-origin assets. Runs with a read-only token and no secrets — safe for fork PRs. Uploads the snapshot as an artifact.
- **`docs-preview-deploy.yml`** (`workflow_run`) — the trusted half, runs only base-branch code. Cross-checks the artifact's PR number against the API (`pulls/<n>.head.sha == workflow_run.head_sha`) so a malicious artifact can't hijack another PR's slot, then publishes to `gh-pages/pr/<n>/` and keeps a sticky comment with the link. Only official `actions/*` are used.
- **`docs-preview-cleanup.yml`** (`pull_request_target: closed`) — deletes `pr/<n>/`. Uses `pull_request_target` because fork-PR close events need a writable token; safe because it never checks out PR code (noted in the file header).

### Verified locally

- `archbee validate` passes (55 docs); `archbee broken-links` → 0 broken (93 links).
- `node tools/preview/snapshot.mjs` → **55/55 pages in ~30s, 153/154 assets** (the one miss is the dev server's own favicon 404, present upstream). Reproducible from the committed lockfile via `npm ci`.
- Served at a simulated Pages subpath and driven headless: root redirect, CSS/fonts applied, **0 script tags / 0 inline handlers**, sidebar navigation and category redirects all work, no same-origin request failures.
- `actionlint` 1.7.10 + shellcheck: all three workflows clean.

### To turn on

Enable Pages once (Settings → Pages → deploy from branch → `gh-pages` / root). The `workflow_run` + Pages path can't be exercised locally, so the first real PR will shake it out.

### Honest caveat

Snapshotting a client-rendered SaaS app is a workaround. If Archbee ships a static export or finishes the GitHub integration @TriplEight tested, this machinery shrinks to a few lines — worth asking their support in parallel. Previews are static, so search/theme-toggle/tabs are inert (a banner in the preview says so).