### PR TITLE
docs(mechanics): add third-party module contribution guidance

### DIFF
--- a/docs/mechanics/About-Mechanics.md
+++ b/docs/mechanics/About-Mechanics.md
@@ -245,6 +245,32 @@ We review all ideas carefully! We may ask additional questions about your idea i
 
 ***
 
+### Contributing a third-party module
+
+If you've designed your own accessory or module for Flipper One — a fan shield, a mounting bracket, anything that attaches to the enclosure but isn't an official part — you're welcome to share it. Third-party modules follow a slightly different process from base model improvements, so they're easy for the team to find and review.
+
+::::hint{type="info"}
+**Keep base model changes and module proposals in separate pull requests**
+
+A pull request that mixes an improvement to the base enclosure with a new module proposal is hard to review and merge — the team can't take one without the other. If you have both, open two pull requests.
+::::
+
+::::WorkflowBlock
+:::WorkflowBlockItem
+**Place your files under `Modules/Third party/`.** In the `CURRENT/<version>/Modules/` folder, create a new directory named after your module, for example `Modules/Third party/fan-shield/`, and put your design files there.
+:::
+
+:::WorkflowBlockItem
+**Add a minimal description.** A short note in your pull request description — what the module does and how it attaches — is enough. You don't need extensive documentation to propose a module.
+:::
+
+:::WorkflowBlockItem
+**Open a pull request**, following the same steps as [submitting your design](#submit-your-design-as-a-pull-request) above.
+:::
+::::
+
+***
+
 ### Suggest your change as a comment on an open task
 
 ::::hint{type="info"}


### PR DESCRIPTION
Closes #366.

Adds a "Contributing a third-party module" section to About-Mechanics.md, covering the three rules requested: keep base-model changes and module proposals in separate PRs, use a dedicated directory, and a minimal description is enough.

I sourced these directly from existing maintainer guidance rather than inventing new rules — r-galeev gave this exact process in flipperone-mechanics#30 (`Modules/Third party/<name>/`, minimal description, open a PR), and NickVolynkin on the same thread explicitly asked for the separate-PR rule when a contributor's module proposal was mixed in with a base-model fix. This just writes down what's already been said informally so future contributors don't have to dig through a PR thread to find it.