### PR TITLE
Fix heading formatting in Wi-Fi tests

### DIFF
--- a/docs/testing/WiFi-DBDC.md
+++ b/docs/testing/WiFi-DBDC.md
@@ -12,7 +12,7 @@ Tests for **DBDC** — Dual-Band Dual-Concurrent operation: running two interfac
 3. Measure throughput on each band with `iperf3`.
 4. Test combinations: AP + STA, AP + AP, STA + STA across band pairs.
 
-## Test log: DBDC mode (build `1322`, 2026-06-25)
+## Test log: DBDC mode (build 1322, 2026-06-25)
 
 Environment: Debian Trixie; made sure that `NetworkManager`, `iw` and `dnsmasq` are present in the system.
 

--- a/docs/testing/WiFi-Monitor.md
+++ b/docs/testing/WiFi-Monitor.md
@@ -16,7 +16,7 @@ Tests for monitor (promiscuous) mode, where the Wi-Fi card captures all traffic 
 Perform an RSN PMKID sniff against a real access point.
 
 
-## Test log: Monitor mode (build `1350`, 2026-06-23)
+## Test log: Monitor mode (build 1350, 2026-06-23)
 
 Environment: Debian Trixie; made sure that `NetworkManager`, `iw` and `dnsmasq` are present in the system.
 


### PR DESCRIPTION
Inline code has regular text size in headings.