### PR TITLE
[open-tasks]: Show active PRs for each task (#369)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+__pycache__

--- a/tools/generate_open_tasks.py
+++ b/tools/generate_open_tasks.py
@@ -120,6 +120,12 @@ class _Section(TypedDict):
     contribution_guide: str
     github_repo: str
 
+class _LinkedPR(TypedDict, total=False):
+    number: int
+    url: str
+    title: str
+    isDraft: bool
+
 class _Issue(TypedDict, total=False):
     repository: _Repository
     number: int
@@ -127,20 +133,28 @@ class _Issue(TypedDict, total=False):
     url: str
     commentsCount: int
     body: str
+    linkedPRs: list[_LinkedPR]
+
+class _DisplayLinkedPR(TypedDict):
+    number: int
+    url: str
+    title: str
+    is_draft: bool
 
 class _DisplayIssue(TypedDict):
     number: int
     title: str
     url: str
     summary: str
-    commentsCount: int
+    comments_count: int
+    linked_prs: list[_DisplayLinkedPR]
 
 class _DisplaySection(_Section):
     issues: list[_DisplayIssue]
 
 
 def fetch_issues() -> list[_Issue]:
-    """Fetch all open `help wanted` issues across the org via the `gh` CLI."""
+    """Fetch all open `help wanted` issues across the org, each with its `linkedPRs` var."""
     result = subprocess.run(
         [
             "gh", "search", "issues",
@@ -152,7 +166,44 @@ def fetch_issues() -> list[_Issue]:
         ],
         capture_output=True, text=True, check=True,
     )
-    return json.loads(result.stdout)  # type: ignore[no-any-return]
+    issues: list[_Issue] = json.loads(result.stdout)
+    for issue in issues:
+        issue["linkedPRs"] = fetch_linked_prs(
+            issue["repository"]["nameWithOwner"], issue["number"]
+        )
+    return issues
+
+
+_LINKED_PRS_QUERY = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      closedByPullRequestsReferences(first: 10, includeClosedPrs: false) {
+        nodes { number url title isDraft }
+      }
+    }
+  }
+}
+"""
+
+
+def fetch_linked_prs(repo_full: str, number: int) -> list[_LinkedPR]:
+    """Return the open PRs linked to `repo_full#number`."""
+    owner, repo = repo_full.split("/", 1)
+    result = subprocess.run(
+        [
+            "gh", "api", "graphql",
+            "-f", f"query={_LINKED_PRS_QUERY}",
+            "-F", f"owner={owner}",
+            "-F", f"repo={repo}",
+            "-F", f"number={number}",
+        ],
+        capture_output=True, text=True, check=True,
+    )
+    data = json.loads(result.stdout)
+    refs = (data.get("data", {}).get("repository", {}) or {}).get("issue") or {}
+    nodes: list[_LinkedPR] = (refs.get("closedByPullRequestsReferences") or {}).get("nodes") or []
+    return nodes
 
 
 def load_issues_from_file(path: Path) -> list[_Issue]:
@@ -238,7 +289,16 @@ def _build_template_sections(issues: list[_Issue]) -> list[_DisplaySection]:
                 "title": html_escape(issue["title"]),
                 "url": html_escape(issue["url"]),
                 "summary": html_escape(make_summary(issue.get("body", ""))),
-                "commentsCount": issue.get("commentsCount", 0),
+                "comments_count": issue.get("commentsCount", 0),
+                "linked_prs": [
+                    {
+                        "number": pr["number"],
+                        "url": html_escape(pr["url"]),
+                        "title": html_escape(pr["title"]),
+                        "is_draft": pr.get("isDraft", False),
+                    }
+                    for pr in issue.get("linkedPRs", [])
+                ],
             }
             for issue in by_repo.get(section["slug"], [])
         ]

--- a/tools/templates/open_tasks.md.j2
+++ b/tools/templates/open_tasks.md.j2
@@ -10,7 +10,7 @@ updatedAt: {{ updated_at }}
 
 This page highlights open tasks across all Flipper One sub-project repositories that need community help or feedback. Each task corresponds to an issue labeled `help wanted` in its respective GitHub repository.
 
-All tasks on this page are organized by sub-project and include a title, a short description, the number of comments, and a link to the task on GitHub. Each sub-project is managed by a team that defines its own contribution process — please review these guidelines before contributing.
+All tasks on this page are organized by sub-project and include a title, a short description, any open pull requests already working on the task, the number of comments, and a link to the task on GitHub. Each sub-project is managed by a team that defines its own contribution process — please review these guidelines before contributing.
 
 :::hint{type="info"}
 Before you join an open task:
@@ -42,9 +42,12 @@ Before you join an open task:
     <td align="left" colSpan="1" rowSpan="1">
       <p>🟢 <a href="{{ issue.url }}">{{ issue.title }}</a></p>
       <p>{{ issue.summary }}</p>
+{% for pr in issue.linked_prs %}
+      <p>🔀 <a href="{{ pr.url }}">#{{ pr.number }}</a> {{ pr.title }}{% if pr.is_draft %} (draft){% endif %}</p>
+{% endfor %}
     </td>
     <td align="center" colSpan="1" rowSpan="1">
-      <p>💬 {{ issue.commentsCount }}</p>
+      <p>💬 {{ issue.comments_count }}</p>
     </td>
   </tr>
 {% endfor %}

--- a/tools/test_generate_open_tasks.py
+++ b/tools/test_generate_open_tasks.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
+import json
+import sys
 import unittest
 from pathlib import Path
-import sys
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from generate_open_tasks import generate_page, make_summary, _Issue
+from generate_open_tasks import fetch_linked_prs, generate_page, make_summary, _Issue
 
 
 class GenerateOpenTasksTest(unittest.TestCase):
@@ -41,12 +43,89 @@ class GenerateOpenTasksTest(unittest.TestCase):
             }
         ]
 
-        page = generate_page(issues, existing_created_at="Wed Apr 08 2026 17:29:37 GMT+0000 (Coordinated Universal Time)")
+        page = generate_page(
+            issues,
+            existing_created_at="Thu Apr 01 2077 17:29:37 GMT+0000 (Coordinated Universal Time)",
+        )
 
         self.assertIn("# 🔌 Hardware tasks", page)
-        self.assertIn("The Hardware sub-project currently has no open `help wanted` tasks.", page)
+        self.assertIn(
+            "The Hardware sub-project currently has no open `help wanted` tasks.", page
+        )
         self.assertIn("# 🐧 Linux (CPU Software) tasks", page)
         self.assertIn("<p><strong>Comments</strong></p>", page)
+
+    def test_generate_page_renders_linked_prs(self) -> None:
+        issues: list[_Issue] = [
+            {
+                "repository": {
+                    "nameWithOwner": "flipperdevices/flipperone-linux-build-scripts"
+                },
+                "title": "Hardware Video Decoding",
+                "number": 13,
+                "url": "https://github.com/flipperdevices/flipperone-linux-build-scripts/issues/13",
+                "body": "Hardware video decoding lol.",
+                "commentsCount": 10,
+                "linkedPRs": [
+                    {
+                        "number": 99,
+                        "url": "https://github.com/flipperdevices/flipperone-linux-build-scripts/pull/99",
+                        "title": 'Add "<MPP>" decoder & fixes',
+                        "isDraft": True,
+                    }
+                ],
+            }
+        ]
+
+        page = generate_page(issues)
+
+        # PR-provided title contains ", <, >, & — all must be HTML-escaped.
+        self.assertIn(
+            '<p>🔀 <a href="https://github.com/flipperdevices/flipperone-linux-build-scripts/pull/99">#99</a> Add &quot;&lt;MPP&gt;&quot; decoder &amp; fixes (draft)</p>',
+            page,
+        )
+
+    def test_fetch_linked_prs_parses_nodes(self) -> None:
+        payload = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "closedByPullRequestsReferences": {
+                            "nodes": [
+                                {
+                                    "number": 99,
+                                    "url": "u",
+                                    "title": "t",
+                                    "isDraft": True,
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        with mock.patch("generate_open_tasks.subprocess.run") as run:
+            run.return_value = mock.Mock(stdout=json.dumps(payload))
+            prs = fetch_linked_prs("flipperdevices/repo", 13)
+
+        self.assertEqual(
+            prs,
+            payload["data"]["repository"]["issue"]["closedByPullRequestsReferences"][
+                "nodes"
+            ],
+        )
+        # owner/repo split correctly passed to gh
+        args = run.call_args[0][0]
+        self.assertIn("owner=flipperdevices", args)
+        self.assertIn("repo=repo", args)
+        self.assertIn("number=13", args)
+
+    def test_fetch_linked_prs_handles_missing_issue(self) -> None:
+        with mock.patch("generate_open_tasks.subprocess.run") as run:
+            run.return_value = mock.Mock(
+                stdout=json.dumps({"data": {"repository": {"issue": None}}})
+            )
+            self.assertEqual(fetch_linked_prs("o/r", 1), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #369

## What
Each `help wanted` issue on the Open-tasks page now lists the open PRs linked to it, rendered as `🔀 #<num> <title> (draft)` rows under the task.

## How
- `fetch_issues()` now enriches each issue with a `linkedPRs` field.
- New `fetch_linked_prs()` runs a `gh api graphql` query per issue to get its associated open PRs.
- `render_section()` emits a `🔀 emoji` line per linked PR with a `(draft)` suffix.
- Intro copy updated to mention "any open pull requests already working on the task".

## Limitations
- `closedByPullRequestsReferences` only returns PRs that will **auto-close** the issue, meaning a PR whose description uses a proper closing keyword, for example: `Fixes #N` / `Closes #N` / `Resolves #N`. So this is only useful if contributors consistently use closing keywords. Catching plain mentions/cross-references would need a timeline/cross-reference query.

- `includeClosedPrs: false` means a **merged** PR drops off the list even if the issue is briefly still open. Self-corrects when the issue closes.

## Tests
- Added `test_generate_page_renders_linked_prs` -- covers the `🔀` row, `(draft)` suffix, and HTML escaping function.
- Added `test_fetch_linked_prs_parses_nodes` -- mocks `gh` and verifies PR-node parsing plus correct `owner`/`repo`/`number` args passed to the GraphQL call.
- Added `test_fetch_linked_prs_handles_missing_issue` -- `issue: null` yields `[]` instead of crashing (always have to remind myself of this test).
- Fixed a pre-existing stale assertion in `test_generate_page_renders_empty_sections_and_comments_header`.

## Notes
- Not sure if this is the semantics you want to use for marking the PR's, I am totally open to discussion on what you all would like to see as a convention for this. 
- sorry about my linter, it's the zed default ;[, if someone has opinion about it, please let me know and I will fix. 
- claude helped a bit with this, mostly with understanding graphql and how it works. 