### PR TITLE
fix(open-tasks): gather issues from all Flipper One repos

### DIFF
--- a/tools/generate_open_tasks.py
+++ b/tools/generate_open_tasks.py
@@ -29,6 +29,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import shorten
 from typing import TypedDict
+import html
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -37,7 +38,10 @@ from jinja2 import Environment, FileSystemLoader
 # anchor on the corresponding "About …" page on docs.flipper.net/one.
 SECTIONS: list[_Section] = [
     {
-        "slug": "flipperdevices/flipperone-hardware",
+        "slug": [
+            "flipperdevices/flipperone-hardware",
+            "flipperdevices/flipperone-debug-probe",
+        ],
         "title": "Hardware",
         "emoji": "🔌",
         "description": "Electrical hardware development: printed circuit boards (PCBs), antennas, and everything related to the electrical design.",
@@ -46,7 +50,7 @@ SECTIONS: list[_Section] = [
         "github_repo": "https://github.com/flipperdevices/flipperone-hardware",
     },
     {
-        "slug": "flipperdevices/flipperone-mechanics",
+        "slug": ["flipperdevices/flipperone-mechanics"],
         "title": "Mechanics",
         "emoji": "⚙️",
         "description": "Mechanical design: enclosures, buttons, connectors, and everything related to the physical construction.",
@@ -55,7 +59,14 @@ SECTIONS: list[_Section] = [
         "github_repo": "https://github.com/flipperdevices/flipperone-mechanics",
     },
     {
-        "slug": "flipperdevices/flipperone-linux-build-scripts",
+        "slug": [
+            "flipperdevices/flipperone-linux-build-scripts",
+            "flipperdevices/flipper-linux-kernel",
+            "flipperdevices/u-boot",
+            "flipperdevices/rkbin",
+            "flipperdevices/rockchip-linux",
+            "flipperdevices/bsb-protobuf",
+        ],
         "title": "Linux (CPU Software)",
         "emoji": "🐧",
         "description": "Build system for the Linux firmware: U-Boot, kernel, root filesystem, and bootable images for the RK3576.",
@@ -64,7 +75,7 @@ SECTIONS: list[_Section] = [
         "github_repo": "https://github.com/flipperdevices/flipperone-linux-build-scripts",
     },
     {
-        "slug": "flipperdevices/flipperone-mcu-firmware",
+        "slug": ["flipperdevices/flipperone-mcu-firmware"],
         "title": "MCU Firmware",
         "emoji": "🕹️",
         "description": "Firmware for the RP2350 co-processor: FreeRTOS, display, buttons, touchpad, LEDs, and power management.",
@@ -73,7 +84,7 @@ SECTIONS: list[_Section] = [
         "github_repo": "https://github.com/flipperdevices/flipperone-mcu-firmware",
     },
     {
-        "slug": "flipperdevices/flipperone-ui",
+        "slug": ["flipperdevices/flipperone-ui"],
         "title": "User Interface",
         "emoji": "🎨",
         "description": "User interface design: operating modes, on-screen graphics, device prints, and FlipCTL.",
@@ -82,7 +93,7 @@ SECTIONS: list[_Section] = [
         "github_repo": "https://github.com/flipperdevices/flipperone-ui",
     },
     {
-        "slug": "flipperdevices/flipperone-testing",
+        "slug": ["flipperdevices/flipperone-testing"],
         "title": "Testing",
         "emoji": "🧪",
         "description": "Hardware validation and test scripts: temperature monitoring, power, CPU, GPU, network, and disk tests.",
@@ -91,13 +102,22 @@ SECTIONS: list[_Section] = [
         "github_repo": "https://github.com/flipperdevices/flipperone-testing",
     },
     {
-        "slug": "flipperdevices/flipperone-docs",
+        "slug": ["flipperdevices/flipperone-docs"],
         "title": "Docs",
         "emoji": "📚",
         "description": "Developer documentation published at docs.flipper.net/one.",
         "task_tracker": "https://github.com/orgs/flipperdevices/projects/10",
         "contribution_guide": "https://docs.flipper.net/one/resources/about-docs#how-to-contribute",
         "github_repo": "https://github.com/flipperdevices/flipperone-docs",
+    },
+    {
+        "slug": ["flipperdevices/flipctl", "flipperdevices/flipctl-fonts"],
+        "title": "FlipCTL",
+        "emoji": "🎛️",
+        "description": "Command-line tool and companion fonts for managing and configuring Flipper One.",
+        "task_tracker": "https://github.com/orgs/flipperdevices/projects/12",
+        "contribution_guide": "https://docs.flipper.net/one/user-interface/about#how-to-contribute",
+        "github_repo": "https://github.com/flipperdevices/flipctl",
     },
 ]
 
@@ -112,7 +132,7 @@ class _Repository(TypedDict):
     nameWithOwner: str
 
 class _Section(TypedDict):
-    slug: str
+    slug: str | list[str]
     title: str
     emoji: str
     description: str
@@ -147,7 +167,7 @@ def fetch_issues() -> list[_Issue]:
             "--owner", ORG,
             "--label", LABEL,
             "--state", "open",
-            "--limit", "200",
+            "--limit", "1000",
             "--json", "repository,title,number,url,body,commentsCount",
         ],
         capture_output=True, text=True, check=True,
@@ -191,12 +211,7 @@ def make_summary(body: str, max_len: int = 120) -> str:
 
 
 def html_escape(text: str) -> str:
-    return (
-        text.replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace('"', "&quot;")
-    )
+    return html.escape(text, quote=True)
 
 
 def archbee_timestamp(dt: datetime) -> str:
@@ -223,6 +238,13 @@ def _content_equal_ignoring_updated_at(a: str, b: str) -> bool:
     return pattern.sub("updatedAt: -", a) == pattern.sub("updatedAt: -", b)
 
 
+def _match_section_slug(slug: str | list[str], repo_full: str) -> bool:
+    """Check if a repo name matches a section slug (single name or list)."""
+    if isinstance(slug, list):
+        return repo_full in slug
+    return repo_full == slug
+
+
 def _build_template_sections(issues: list[_Issue]) -> list[_DisplaySection]:
     """Prepare section and issue data for the Open Tasks Jinja template."""
     by_repo: dict[str, list[_Issue]] = {}
@@ -232,6 +254,10 @@ def _build_template_sections(issues: list[_Issue]) -> list[_DisplaySection]:
 
     sections: list[_DisplaySection] = []
     for section in SECTIONS:
+        matched_issues: list[_Issue] = []
+        for repo_full, repo_issues in by_repo.items():
+            if _match_section_slug(section["slug"], repo_full):
+                matched_issues.extend(repo_issues)
         rendered_issues: list[_DisplayIssue] = [
             {
                 "number": issue["number"],
@@ -240,7 +266,7 @@ def _build_template_sections(issues: list[_Issue]) -> list[_DisplaySection]:
                 "summary": html_escape(make_summary(issue.get("body", ""))),
                 "commentsCount": issue.get("commentsCount", 0),
             }
-            for issue in by_repo.get(section["slug"], [])
+            for issue in matched_issues
         ]
         rendered_issues.sort(key=lambda i: i["number"], reverse=True)
         sections.append({**section, "issues": rendered_issues})


### PR DESCRIPTION
## Summary

Fixes #371. The `generate_open_tasks.py` script was silently dropping issues from repos not hardcoded in the `SECTIONS` list. The `_build_template_sections` function used `by_repo.get(section["slug"], [])` which only matched a single repo name — any help-wanted issue from repos outside the original 7-entry `SECTIONS` list was fetched by the org-wide `gh search issues` call but then discarded during rendering.

## Investigation findings

The original `--limit 200` was **not** the problem — only 18 total "help wanted" issues exist across the entire `flipperdevices` org. The real issue was that `SECTIONS` was missing multiple repos:

- **flipper-linux-kernel** had a help-wanted issue (#6) that was being _fetched by gh search_ but then silently dropped during rendering because it wasnt in `SECTIONS`
- Several Linux build ecosystem repos (u-boot, rkbin, rockchip-linux, bsb-protobuf) were completely absent
- FlipCTL (flipctl, flipctl-fonts) had no section at all
- **flipperone-debug-probe** was a completely missing Flipper One sub-project

## Changes

### Repository coverage added
- **Hardware**: added `flipperdevices/flipperone-debug-probe` (debug probe for Flipper One based on RP2350)
- **Linux (CPU Software)**: extended from 1 repo to 6 — added `flipper-linux-kernel`, `u-boot`, `rkbin`, `rockchip-linux`, and `bsb-protobuf`
- **FlipCTL**: new section covering `flipctl` and `flipctl-fonts`

### Code changes
1. **`slug` field**: changed from `str` to `list[str]` for all sections to support multi-repo sections
2. **`_match_section_slug()`**: new helper that correctly matches a repo name against a section slug (single or list)
3. **`_build_template_sections()`**: fixed to iterate all fetched repos and use `_match_section_slug` for matching instead of the original `by_repo.get(slug, [])`
4. **`--limit`**: bumped from 200 to 1000 for future-proofing
5. **HTML escaping**: replaced manual char-by-char escaping with stdlib `html.escape()`

### What was NOT changed
- Kept the `gh search issues` approach (single call, works correctly, supports `commentsCount` natively)
- Did NOT switch to per-repo `gh issue list` (which has a different field name for comment counts: `comments` returns an array, not a count)

## Testing
- Verified against a live snapshot of all 18 open help-wanted issues across the org
- Confirmed `flipper-linux-kernel#6` now appears under Linux (CPU Software) — previously silently dropped
- All 3 existing unit tests pass
- Generated output renders all 8 sections correctly (including sections with "no open tasks")

Closes #371