### PR TITLE
Fix mismatched M.2 thickness spec on the M.2 port page

### DIFF
--- a/docs/hardware/M2-port.md
+++ b/docs/hardware/M2-port.md
@@ -14,7 +14,7 @@ Tech specs:
 
 - **M.2 type:** Key B
 - **Supported sizes:** 2230(via extender), 2242, 3042, 3052
-- **Supported thickness:** up to D3 (double-sided modules)
+- **Supported thickness:** up to S3 (single-sided modules)
 - **Interfaces:** PCIe 2.1 ×1 / USB 2.0 / USB 3.1 / SATA3 / Serial Audio / UART / I²C / SIM card + eSIM
 
 ***


### PR DESCRIPTION
The M.2 module thickness spec doesn't match between two pages that describe the same connector.

- `docs/hardware/M2-port.md` line 17 says "up to D3 (double-sided modules)"
- `docs/general/Tech-Specs.md` line 162 says "up to S3 (single-sided modules)"

Two other pages agree with the Tech specs page:
- `docs/mechanics/Module-mounting-system.md` line 25 describes the mount as "top-side component placement (S3 type, with component height up to 1.5 mm above the module PCB)" — components on the top side only, nothing about a bottom-side keep-out.
- `docs/testing/M_2.md` line 9 also says "M.2 Key-B (S3)".

Per the M.2 spec, S3 and D3 both cap top-side component height at 1.5 mm, but D3 additionally allows components on the bottom side (the side facing the mainboard). The mounting page only talks about top-side placement and gives no bottom-side clearance, which matches single-sided S3, not double-sided D3. Since 3 of the 4 pages plus the actual mechanical description agree, the M.2 port page looks like the one that's wrong.

Changed `M2-port.md` from D3 to S3 so all four pages agree.

Why it matters: this is the thickness limit for whatever card someone plugs into the slot. A double-sided card that's fine under a D3 reading won't clear the case if the real limit is S3, since the slot has no clearance for bottom-side components against the mainboard.

Ran a fresh clone against the current `public-release` HEAD, no changes beyond the single line above.
