### PR TITLE
Fix broken section anchors and an image path, add missing eSIM mention

### DIFF
--- a/docs/dev-log/4.md
+++ b/docs/dev-log/4.md
@@ -74,7 +74,7 @@ Watch our industrial designer _@r-galeev_ test the fan shield with a Flipper One
 
 ::embed[]{url="https://www.youtube.com/watch?v=ZmNi7M4flao"}
 
-You're welcome to propose your own Flipper One modules. Check out the [contribution guide](../mechanics/About-Mechanics.md#contributing-a-third-party-module) and open a pull request in [flipperdevices/flipperone-mechanics](https://github.com/flipperdevices/flipperone-mechanics).
+You're welcome to propose your own Flipper One modules. Check out the [contribution guide](../mechanics/About-Mechanics.md#contribute-a-third-party-module) and open a pull request in [flipperdevices/flipperone-mechanics](https://github.com/flipperdevices/flipperone-mechanics).
 
 ---
 
@@ -83,7 +83,7 @@ You're welcome to propose your own Flipper One modules. Check out the [contribut
 
 - We're still looking for a FlipCTL architecture lead. Read the [blog post about FlipCTL](https://blog.flipper.net/flipctl-our-gui-framework-for-embedded-linux-systems/) and propose your vision of its architecture.
 - Building a project that helps test and improve Flipper One? Please tell us about it in the comments or add it on the [community projects](../community/community.md) page.
-- 3rd-party module contributions are welcome! Check out the [contribution guide](../mechanics/About-Mechanics.md#contributing-a-third-party-module) and open a pull request in [flipperdevices/flipperone-mechanics](https://github.com/flipperdevices/flipperone-mechanics).
+- 3rd-party module contributions are welcome! Check out the [contribution guide](../mechanics/About-Mechanics.md#contribute-a-third-party-module) and open a pull request in [flipperdevices/flipperone-mechanics](https://github.com/flipperdevices/flipperone-mechanics).
 - We have many other tasks open to the community! See the full list on the [🚧 Open tasks](https://docs.flipper.net/one/open-tasks) page. 
 
 

--- a/docs/dev-log/5.md
+++ b/docs/dev-log/5.md
@@ -67,7 +67,7 @@ Flipper One UI uses three pixel fonts: [HaxrCorp 4090](https://github.com/flippe
 
 - We're looking for a FlipCTL architecture lead. Learn more in the [blog post about FlipCTL](https://blog.flipper.net/flipctl-our-gui-framework-for-embedded-linux-systems/).
 - Building a project that helps test or improve Flipper One? Add it to the [community projects](../community/community.md) page.
-- 3rd-party module contributions are welcome! Check out the [contribution guide](../mechanics/About-Mechanics.md#contributing-a-third-party-module) and open a pull request in [flipperdevices/flipperone-mechanics](https://github.com/flipperdevices/flipperone-mechanics).
+- 3rd-party module contributions are welcome! Check out the [contribution guide](../mechanics/About-Mechanics.md#contribute-a-third-party-module) and open a pull request in [flipperdevices/flipperone-mechanics](https://github.com/flipperdevices/flipperone-mechanics).
 - We have many other tasks open to the community! See the full list on the [🚧 Open tasks](https://docs.flipper.net/one/open-tasks) page. 
 
 

--- a/docs/general/Tech-Specs.md
+++ b/docs/general/Tech-Specs.md
@@ -160,7 +160,7 @@ The M.2 expansion port is at the back of the device, under the Back Plate.
 - **M.2 type:** Key B
 - **Supported sizes:** 2230 (via extender), 2242, 3042, 3052
 - **Supported thickness:** up to S3 (single-sided modules)
-- **Interfaces:** PCIe 2.1 x1 / USB 2.0 / USB 3.1 / SATA3 / Serial Audio / UART / I2C / SIM card
+- **Interfaces:** PCIe 2.1 x1 / USB 2.0 / USB 3.1 / SATA3 / Serial Audio / UART / I2C / SIM card + eSIM
 
 ### M.2 port pinout
 

--- a/docs/testing/About-Testing.md
+++ b/docs/testing/About-Testing.md
@@ -68,7 +68,7 @@ To avoid duplicating a fast-changing list of implemented tests here, use the rep
 ## How to contribute
 
 The Testing sub-project accepts contributions in three forms:
-* **[Comments on open task](/.#comment-on-an-open-task)** with ideas, suggestions, and improvements.
+* **[Comments on open task](./#comment-on-an-open-task)** with ideas, suggestions, and improvements.
 * **[Testing and uploading test results](./#test-and-report-the-results)** to open testing tasks. 
 * **[Pull requests for test improvements](./#contribute-via-a-pull-request)**.
 

--- a/docs/testing/Video-decoding.md
+++ b/docs/testing/Video-decoding.md
@@ -15,7 +15,7 @@ This section describes how to properly test hardware video decoding.
 
 # Rockchip RK3576 Hardware Video decoders
 
-![Rockchip RK3576 Hardware Video decoders](files/pics/rk3576_hardware_video_decoders.png)
+![Rockchip RK3576 Hardware Video decoders](/files/pics/rk3576_hardware_video_decoders.png)
 
 ***
 


### PR DESCRIPTION
Found a few broken internal links while reading through the docs. Three links in the dev-log pages point to `About-Mechanics.md#contributing-a-third-party-module`, but the actual heading is "Contribute a third-party module", so the anchor should be `#contribute-a-third-party-module` - fixed all three. About-Testing.md had one bullet using `/.#comment-on-an-open-task` while its two sibling bullets right below it correctly use `./#`, so that one was just a typo.

Also fixed an image reference in Video-decoding.md that was missing its leading slash (every other image in the repo uses `/files/pics/...`, this one used a bare relative path), and added "eSIM" to the M.2 interfaces list on Tech-Specs.md, since the same list on M2-port.md and M2-Modules.md both include it and this page just didn't.

None of these show up in the broken-links CI check since it only validates that the target file exists, not that the anchor fragment resolves to a real heading - worth keeping in mind for future doc PRs.
