### PR TITLE
Add ESP32-E22 review and fix sSDR compatibility notes on the M.2 modules page

### DIFF
--- a/docs/hardware/M2-Modules.md
+++ b/docs/hardware/M2-Modules.md
@@ -28,11 +28,23 @@ M.2 cellular modems add 4G/5G connectivity over a SIM or eSIM, turning Flipper O
 
 M.2 Wi-Fi cards add wireless networking and, on most modules, Bluetooth as well.
 
+The [ESP32-E22](https://www.espressif.com/en/products/socs/esp32-e22) is a Wi-Fi 6E and Bluetooth 5.4 co-processor from Espressif. It recently [passed Wi-Fi CERTIFIED 6E testing](https://www.espressif.com/en/news/E22_Wi-Fi_6E_Certificate) and ships with an [open-source Linux driver](https://github.com/espressif/esp32e22-linux-driver), which is why people keep asking us to add it here.
+
+:::hint{type="warning"}
+We can't confirm the ESP32-E22 fits Flipper One's M.2 port yet. Espressif's module, the [ESP32-E22-M2-1](https://www.espressif.com/en/products/modules?id=ESP32-E22), is an M.2 2230 card that lists SDIO 3.0 as a host interface alongside PCIe 2.1. SDIO is only wired on Key E sockets, not on Key B, and Espressif hasn't published the module's key type. Every SDIO-capable Wi-Fi/Bluetooth M.2 card we're aware of uses Key E for that reason, which would stop it from going into Flipper One's Key B slot at all.
+
+The Linux driver currently uses PCIe for Wi-Fi and USB for Bluetooth, both of which Key B does carry. If a Key B version of this module shows up, it should work over those two interfaces. Until then, we're leaving the ESP32-E22 off the confirmed list.
+:::
+
 ***
 
 ## SDR radios
 
-Software-defined radio modules turn Flipper One into a portable SDR platform for receiving and transmitting across a wide range of frequencies. One example is the [sSDR by Wavelet Lab](https://www.crowdsupply.com/wavelet-lab/ssdr).
+Software-defined radio modules turn Flipper One into a portable SDR platform for receiving and transmitting across a wide range of frequencies. One example is the [sSDR by Wavelet Lab](https://www.crowdsupply.com/wavelet-lab/ssdr), though which revision you get matters for fit.
+
+:::hint{type="warning"}
+Flipper One's M.2 port is Key B only. The current sSDR Rev3 is keyed M (PCIe 3.0 ×4 + USB 2.0) and won't go into a Key B socket at all, since Key M sits at a different notch. The older Rev2 is keyed B+M (PCIe 2.0 ×2 + USB 2.0), so it does fit mechanically, but Flipper One only wires a single PCIe lane. Best case, the card links down to PCIe ×1 with less bandwidth than on a native ×2 slot; worst case, it needs both lanes and won't link up. USB 2.0 works over Key B's USB pins on either revision. See [Wavelet Lab's own specs](https://docs.wsdr.io/hardware/ssdr.html) for the full breakdown.
+:::
 
 ***
 


### PR DESCRIPTION
Closes #405.

I looked into the ESP32-E22 to answer the issue. It's a real, certified part (Espressif's [product page](https://www.espressif.com/en/products/socs/esp32-e22), the [Wi-Fi CERTIFIED 6E announcement](https://www.espressif.com/en/news/E22_Wi-Fi_6E_Certificate)), and the Linux driver is genuinely open source ([espressif/esp32e22-linux-driver](https://github.com/espressif/esp32e22-linux-driver)). But I couldn't confirm it fits our M.2 port. Espressif's module page lists SDIO 3.0 as one of the ESP32-E22-M2-1's host interfaces, and SDIO only exists on Key E sockets, not Key B. Espressif hasn't published the module's actual key type, but I couldn't find a single SDIO-capable Wi-Fi/Bluetooth M.2 card that isn't Key E, so I wrote the entry as "unconfirmed, probably doesn't fit" rather than adding it to the list outright. The driver currently uses PCIe for Wi-Fi and USB for Bluetooth, which are both wired on Key B, so a Key B variant of this module would likely work if one ever ships.

While I was in there I also fixed the sSDR listing. It's named as an SDR example with a plain crowdsupply link and no caveats, but per Wavelet Lab's own docs, the current Rev3 is Key M and can't physically go into our Key B slot, and Rev2 is B+M so it fits mechanically but only gets a single PCIe lane out of the two it wants. Left the USB 2.0 path in as the one part that works cleanly on both revisions.
