### PR TITLE
Fix charger and fuel gauge part numbers to match the shipped hardware

### DIFF
--- a/docs/general/Tech-Specs.md
+++ b/docs/general/Tech-Specs.md
@@ -115,7 +115,7 @@ This page describes the full technical specifications of the Flipper One. Since 
 - **Battery energy:** 24000 mWh
 - **Battery capacity:** 7000 mAh ⚠️ (not final)
 - **Charger IC:** TI BQ25792, up to 3.32 A
-- **Fuel Gauge:** TI BQ28Z610
+- **Fuel Gauge:** TI BQ28Z620
 - **Charging:** via USB-C1 port, USB Power Delivery supported
 
 ***

--- a/docs/mechanics/Heatsink.md
+++ b/docs/mechanics/Heatsink.md
@@ -17,7 +17,7 @@ The main heat sources inside Flipper One are:
 * **RK3576 SoC.** Up to **5.5 W** under maximum load (CPU + GPU + NPU simultaneously).
 * **RK806S PMIC.** Up to around **2 W** at peak SoC load.
 * **DDR5 RAM.** Up to **1.5 W** during memory-intensive operations.
-* **BQ25798 charger.** Up to **1 W** while fast-charging the battery.
+* **BQ25792 charger.** Up to **1 W** while fast-charging the battery.
 
 !["Location of the main heat-generating chips on the Flipper One PCB"](/files/pics/flipper-one-hot-chips.png "Location of the main heat-generating chips on the Flipper One PCB")
 


### PR DESCRIPTION
Fixes two of the three mismatches from #420, the two that turned out to be provable from this org's own code.

The charger is a BQ25792: the MCU firmware ships a driver for exactly that part (`flipperone-mcu-firmware/lib/drivers/bq25792/`), and the device tree in your u-boot fork declares `compatible = "ti,bq25792"` (`dts/upstream/src/arm64/rockchip/rk3576-flipper-one-rev-f0b0c1.dts`, the `charger@6b` node). So Tech-Specs had it right and Heatsink.md's BQ25798 was the stale one.

The fuel gauge is a BQ28Z620: same firmware has `lib/drivers/bq28z620/`, and the DTS comment on the gauge node says it outright: `compatible = "ti,bq28z610"; /* really bq28z620: tbc if we need a new compatible */`. So Power-subsystem.md had it right and Tech-Specs' BQ28Z610 was stale. I left the DTS compatible string out of the docs since that's a kernel binding detail, and the pages name physical parts.

I didn't touch the battery energy number (the third item in #420). The DTS gives 3100 mAh design capacity with a 6.0 to 8.65 V window, and both 22.9 Wh and 24 Wh fall out of that depending on which nominal cell voltage you use, so that one still needs a call from someone who knows the cell's rated spec.
