### PR TITLE
Fix a self-contradicting microSD spec and a dead Rockchip wiki link

### DIFF
--- a/docs/general/Tech-Specs.md
+++ b/docs/general/Tech-Specs.md
@@ -63,7 +63,7 @@ This page describes the full technical specifications of the Flipper One. Since 
 - **HDMI out:** full-size, v2.1, CEC support, 4K @ 120 Hz
 - **Ethernet:** 2× RJ45, Gigabit
 - **3.5 mm audio jack:** stereo out and microphone input (TRRS)
-- **MicroSD card slot:** supports UHS-I SDR104
+- **MicroSD card slot:** ⚠️ (UHS-I SDR104 — needs verification)
 - **SIM card slot:** Nano SIM (4FF), passively connected to M.2 port
 
 ***

--- a/docs/resources/rockchip/RK3576-Boot-flow.md
+++ b/docs/resources/rockchip/RK3576-Boot-flow.md
@@ -8,7 +8,7 @@ updatedAt: Thu May 21 2026 00:00:00 GMT+0000 (Coordinated Universal Time)
 
 This page describes the cold-boot sequence of the Rockchip RK3576 SoC used in Flipper One: from the on-chip Boot ROM through DDR initialization, SPL, the FIT-packaged main bootloader (U-Boot + ARM Trusted Firmware-A), and finally the operating system. It also documents the on-flash layout that the Boot ROM and SPL rely on.
 
-The legacy [Rockchip Boot option wiki](https://opensource.rock-chips.com/wiki_Boot_option) covers older SoCs (RK33xx and earlier) and uses obsolete terminology (`miniloader`, `idbloader`) that is **not** part of the current RK3576 stack.
+The legacy Rockchip Boot option wiki (`opensource.rock-chips.com/wiki_Boot_option`, no longer resolving) covers older SoCs (RK33xx and earlier) and uses obsolete terminology (`miniloader`, `idbloader`) that is **not** part of the current RK3576 stack.
 
 ***
 


### PR DESCRIPTION
Two unrelated accuracy fixes I hit while reading through the hardware pages.

**microSD spec contradicts itself inside one file.** `Tech-Specs.md` states the slot spec twice. Under Ports it's asserted flat out, under Memory and storage it carries the "needs verification" warning:

- line 66: `- **MicroSD card slot:** supports UHS-I SDR104`
- line 109: `- **MicroSD card slot:** ⚠️ (UHS-I SDR104 — needs verification)`

No other page mentions microSD, so there's nothing to break the tie. I matched line 66 to the cautious version rather than the confident one, since dropping a caveat needs evidence it's been resolved and I don't have that. If the slot has since been verified, the fix is the other direction and I'm happy to flip it.

**Dead Rockchip wiki link.** `RK3576-Boot-flow.md` links to `opensource.rock-chips.com/wiki_Boot_option`. That domain doesn't resolve any more — it CNAMEs to `opensource.rock-chips.com.qtlgslb.com.`, which returns NXDOMAIN from both Cloudflare and Google DoH, so it's the zone being gone rather than one resolver being unhappy. There's no Wayback snapshot to point at either.

The sentence is still worth keeping, since it's warning people off the obsolete `miniloader`/`idbloader` terminology, so I left the text and just removed the link.

One thing I couldn't settle, flagging rather than guessing: `Power-subsystem.md:21` says the battery is **22.9 Wh** and `Tech-Specs.md:115` says **24000 mWh**. Same 2-cell pack. I can't tell which is canonical from the repo alone, so I left both alone — happy to send a follow-up once someone confirms the real number.
