### PR TITLE
ci: run the docs validator test suite

### DIFF
--- a/.github/workflows/test-open-tasks-generator.yml
+++ b/.github/workflows/test-open-tasks-generator.yml
@@ -33,3 +33,8 @@ jobs:
 
       - name: Test generator
         run: python3 tools/test_generate_open_tasks.py
+
+      # tools/validate_docs.py gates every pull request from the Validate
+      # workflow, so its own test suite has to run whenever the tool changes.
+      - name: Test docs validator
+        run: python3 tools/test_validate_docs.py


### PR DESCRIPTION
## What's wrong

`tools/test_validate_docs.py` has never run in CI. `test-open-tasks-generator.yml` runs `mypy` over every file in `tools/` — `validate_docs.py` included — but only executes `test_generate_open_tasks.py`. The validator's 37 tests are dead weight, so a regression in the tool that gates every pull request from the Validate workflow would go unnoticed.

## How to reproduce

`.github/workflows/test-open-tasks-generator.yml` has a single test step, `python3 tools/test_generate_open_tasks.py`. Nothing anywhere in `.github/workflows/` mentions `test_validate_docs.py`.

## The fix

One extra step next to the existing one. Both suites are stdlib `unittest` and need no new dependencies; together they run in well under a second. The workflow already triggers on `tools/**`, which is exactly when these tests need to run.

## Note for maintainers

The workflow is still called "Test Open Tasks generator" though it already covers all of `tools/`. Renaming it would be tidier, but it changes the check name and could break branch protection rules, so I left it alone — happy to rename in a follow-up if you'd prefer.

## Checks

* `python3 tools/test_generate_open_tasks.py` → 11 tests OK
* `python3 tools/test_validate_docs.py` → 37 tests OK (on this branch, without PR #1's changes)